### PR TITLE
Bugfix/5: MessageTemplate cannot be saved 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       # but we let pre-commit take care of the file filtering.
       - id: black
         name: black
-        args: [ '--check' ]
+#        args: [ '--check' ]
         entry: black
         language: python
         types: [ python ]

--- a/src/bitcaster/forms/message.py
+++ b/src/bitcaster/forms/message.py
@@ -23,11 +23,6 @@ class MessageEditForm(forms.ModelForm[Message]):
         required=False, widget=TinyMCE(attrs={"class": "aaaa"}, mce_attrs={"setup": "setupTinyMCE", "height": "400px"})
     )
     context = forms.JSONField(widget=SvelteJSONEditorWidget(), required=False)
-    content_type = forms.CharField(widget=forms.HiddenInput)
-
-    class Meta:
-        model = Message
-        fields = ("subject", "content", "html_content", "context", "recipient")
 
     @property
     def media(self) -> forms.Media:
@@ -38,6 +33,14 @@ class MessageEditForm(forms.ModelForm[Message]):
             "jquery.init.js",
         ]
         return orig + forms.Media(js=["admin/js/%s" % url for url in js])
+
+    class Meta:
+        model = Message
+        fields = ("subject", "content", "html_content", "context", "recipient")
+
+
+class MessageRenderForm(MessageEditForm):
+    content_type = forms.CharField(widget=forms.HiddenInput)
 
 
 class MessageChangeForm(forms.ModelForm[Message]):


### PR DESCRIPTION
Fixed content_type parameter usage in TemplateMessage edit view preventing new form from being submitted
Fixed initial usage in TemplateMessage form preventing instance data being displayed 
Added confirmation message on TemplateMessage edit form successful submit 
Enabled automatic black tool execution on pre-commit