### PR TITLE
upgrade pypa/gh-action-pypi-publish to v1.13.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           name: ${{ env.dists-artifact-name }}
           path: dist/
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           attestations: true
   dockerize:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Test](https://github.com/bitcaster-io/bitcaster/actions/workflows/test.yml/badge.svg)](https://github.com/bitcaster-io/bitcaster/actions/workflows/test.yml)
 [![Lint](https://github.com/bitcaster-io/bitcaster/actions/workflows/lint.yml/badge.svg)](https://github.com/bitcaster-io/bitcaster/actions/workflows/lint.yml)
 [![security scan](https://github.com/bitcaster-io/bitcaster/actions/workflows/security.yml/badge.svg)](https://github.com/bitcaster-io/bitcaster/actions/workflows/security.yml)
-![GitHub Code Scanning](https://img.shields.io/github/search/bitcaster-io/bitcaster/label%3Asecurity-event?label=security%20issues)
+[![GitHub Code Scanning](https://img.shields.io/github/search/bitcaster-io/bitcaster/label%3Asecurity-event?label=security%20issues)](https://github.com/bitcaster-io/bitcaster/security)
 [![codecov](https://codecov.io/gh/bitcaster-io/bitcaster/graph/badge.svg?token=kAuZEX5k5o)](https://codecov.io/gh/bitcaster-io/bitcaster)
 [![License](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbitcaster-io%2Fbitcaster%2Fdevelop%2Fpyproject.toml&query=project.license.text&label=license)](https://github.com/bitcaster-io/bitcaster?tab=License-1-ov-file)
 [![Docker](https://img.shields.io/docker/pulls/os4d/bitcaster)](https://hub.docker.com/r/os4d/bitcaster/tags)


### PR DESCRIPTION
Also, fix the security badge link in the README.

# Legal Boilerplate

Look, I get it.
Contributing to Bitcaster, I retain all rights, title and interest in and to my contributions, and by keeping
this boilerplate intact I confirm that Bitcaster can use, modify, copy, and redistribute my contributions,
under Bitcaster's choice of terms.
