### PR TITLE
Added Constance variable OCCURRENCE_MAX_RETENTION

### DIFF
--- a/src/bitcaster/admin/__init__.py
+++ b/src/bitcaster/admin/__init__.py
@@ -4,6 +4,7 @@ from .application import ApplicationAdmin
 from .assignment import AssignmentAdmin
 from .attachment import AttachmentAdmin
 from .channel import ChannelAdmin
+from .constance import CustomConstanceAdmin
 from .distribution import DistributionListAdmin
 from .event import EventAdmin
 from .group import GroupAdmin
@@ -28,6 +29,7 @@ __all__ = [
     "AssignmentAdmin",
     "AttachmentAdmin",
     "ChannelAdmin",
+    "CustomConstanceAdmin",
     "DistributionListAdmin",
     "EventAdmin",
     "GroupAdmin",

--- a/src/bitcaster/admin/constance.py
+++ b/src/bitcaster/admin/constance.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
 from bitcaster.admin.base import BitcasterModelAdmin
-from bitcaster.auth.constants import DEFAULT_OCCURRENCE_DEFAULT_RETENTION, DEFAULT_OCCURRENCE_MAX_RETENTION
+from bitcaster.constants import DEFAULT_OCCURRENCE_DEFAULT_RETENTION, DEFAULT_OCCURRENCE_MAX_RETENTION
 from bitcaster.forms.unfold import UnfoldForm
 
 

--- a/src/bitcaster/admin/constance.py
+++ b/src/bitcaster/admin/constance.py
@@ -1,0 +1,23 @@
+from constance.admin import ConstanceAdmin
+from constance.base import Config
+from constance.forms import ConstanceForm
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+from bitcaster.admin.base import BitcasterModelAdmin
+from bitcaster.auth.constants import DEFAULT_OCCURRENCE_DEFAULT_RETENTION, DEFAULT_OCCURRENCE_MAX_RETENTION
+from bitcaster.forms.unfold import UnfoldForm
+
+
+class CustomConstanceForm(UnfoldForm, ConstanceForm):
+    def clean(self):
+        cleaned_data = super().clean()
+        default_val = cleaned_data.get("OCCURRENCE_DEFAULT_RETENTION", DEFAULT_OCCURRENCE_DEFAULT_RETENTION)
+        max_val = cleaned_data.get("OCCURRENCE_MAX_RETENTION", DEFAULT_OCCURRENCE_MAX_RETENTION)
+
+        if default_val > max_val:
+            raise ValidationError(_("Default retention cannot be greater than maximum retention."))
+
+
+class CustomConstanceAdmin(ConstanceAdmin, BitcasterModelAdmin[Config]):
+    change_list_form = CustomConstanceForm

--- a/src/bitcaster/admin/register.py
+++ b/src/bitcaster/admin/register.py
@@ -1,7 +1,9 @@
+from constance.admin import Config
 from django.contrib import admin
 
 from bitcaster import models
 
+from . import CustomConstanceAdmin
 from .address import AddressAdmin
 from .api_key import ApiKeyAdmin
 from .application import ApplicationAdmin
@@ -36,6 +38,8 @@ admin.site.register(models.LogEntry, LogEntryAdmin)
 admin.site.unregister(FlagState)
 admin.site.register(FlagState, FlagStateAdmin)
 
+admin.site.unregister([Config])
+admin.site.register([Config], CustomConstanceAdmin)
 
 admin.site.register(models.Address, AddressAdmin)
 admin.site.register(models.ApiKey, ApiKeyAdmin)

--- a/src/bitcaster/auth/constants.py
+++ b/src/bitcaster/auth/constants.py
@@ -1,8 +1,6 @@
 from django.db.models import TextChoices
 
 DEFAULT_GROUP_NAME = "Default"
-DEFAULT_OCCURRENCE_DEFAULT_RETENTION = 30
-DEFAULT_OCCURRENCE_MAX_RETENTION = 360
 
 
 class Scope(TextChoices):

--- a/src/bitcaster/auth/constants.py
+++ b/src/bitcaster/auth/constants.py
@@ -1,6 +1,8 @@
 from django.db.models import TextChoices
 
 DEFAULT_GROUP_NAME = "Default"
+DEFAULT_OCCURRENCE_DEFAULT_RETENTION = 30
+DEFAULT_OCCURRENCE_MAX_RETENTION = 360
 
 
 class Scope(TextChoices):

--- a/src/bitcaster/config/fragments/constance.py
+++ b/src/bitcaster/config/fragments/constance.py
@@ -1,4 +1,8 @@
-from bitcaster.auth.constants import DEFAULT_GROUP_NAME
+from bitcaster.auth.constants import (
+    DEFAULT_GROUP_NAME,
+    DEFAULT_OCCURRENCE_DEFAULT_RETENTION,
+    DEFAULT_OCCURRENCE_MAX_RETENTION,
+)
 
 CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
 
@@ -22,7 +26,16 @@ CONSTANCE_CONFIG = {
     "SYSTEM_EMAIL_CHANNEL": ("", "System Email", "email_channel"),
     "NEW_USER_IS_STAFF": (False, "Set any new user as staff", bool),
     "NEW_USER_DEFAULT_GROUP": (DEFAULT_GROUP_NAME, "Group to assign to any new user", "group_select"),
-    "OCCURRENCE_DEFAULT_RETENTION": (30, "Number of days of Occurrences retention", int),
+    "OCCURRENCE_DEFAULT_RETENTION": (
+        DEFAULT_OCCURRENCE_DEFAULT_RETENTION,
+        "Number of days of Occurrences retention",
+        int,
+    ),
+    "OCCURRENCE_MAX_RETENTION": (
+        DEFAULT_OCCURRENCE_MAX_RETENTION,
+        "Maximum number of days of Occurrences retention",
+        int,
+    ),
     "ATTACHMENT_DOWNLOAD_KEY_SALT": ("", "Salt to apply when generating attachment download keys", str),
     "ATTACHMENT_BASE_URL": ("http://localhost", "The base URL for attachment file downloads (no trailing slash)", str),
 }

--- a/src/bitcaster/config/fragments/constance.py
+++ b/src/bitcaster/config/fragments/constance.py
@@ -1,8 +1,7 @@
 from bitcaster.auth.constants import (
     DEFAULT_GROUP_NAME,
-    DEFAULT_OCCURRENCE_DEFAULT_RETENTION,
-    DEFAULT_OCCURRENCE_MAX_RETENTION,
 )
+from bitcaster.constants import DEFAULT_OCCURRENCE_DEFAULT_RETENTION, DEFAULT_OCCURRENCE_MAX_RETENTION
 
 CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
 

--- a/src/bitcaster/constants.py
+++ b/src/bitcaster/constants.py
@@ -105,3 +105,5 @@ class SystemEvent(enum.Enum):
 
 
 bitcaster = Bitcaster()
+DEFAULT_OCCURRENCE_DEFAULT_RETENTION = 30
+DEFAULT_OCCURRENCE_MAX_RETENTION = 360

--- a/src/bitcaster/forms/unfold.py
+++ b/src/bitcaster/forms/unfold.py
@@ -53,14 +53,19 @@ class UnfoldForm(forms.Form):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         for field in self.fields.values():
-            if widget := WIDGETS_OVERRIDES.get(field.__class__):
-                if isinstance(field.widget, forms.Textarea):
-                    field.widget = widgets.UnfoldAdminTextareaWidget()
-                elif hasattr(field, "choices"):
-                    field.widget = widget()
-                    field.widget.choices = field.choices
-                else:
-                    field.widget = widget()
+            if isinstance(field.widget, forms.HiddenInput):
+                continue
+
+            for field_class, widget in WIDGETS_OVERRIDES.items():
+                if isinstance(field, field_class):
+                    if isinstance(field.widget, forms.Textarea):
+                        field.widget = widgets.UnfoldAdminTextareaWidget()
+                    elif hasattr(field, "choices"):
+                        field.widget = widget()
+                        field.widget.choices = field.choices
+                    else:
+                        field.widget = widget()
+                    break
 
 
 # kudos to https://github.com/unfoldadmin/django-unfold/issues/180
@@ -75,13 +80,18 @@ class UnfoldAdminForm(AdminForm):
     ) -> None:
         super().__init__(form, fieldsets, prepopulated_fields, readonly_fields, model_admin)
         for field in self.form.fields.values():
-            if widget := WIDGETS_OVERRIDES.get(field.__class__):
-                if isinstance(field.widget, forms.Textarea):
-                    field.widget = widgets.UnfoldAdminTextareaWidget()
-                elif hasattr(field, "choices"):
-                    field.widget.choices = field.choices
-                else:
-                    field.widget = widget()
+            if isinstance(field.widget, forms.HiddenInput):
+                continue
+
+            for field_class, widget in WIDGETS_OVERRIDES.items():
+                if isinstance(field, field_class):
+                    if isinstance(field.widget, forms.Textarea):
+                        field.widget = widgets.UnfoldAdminTextareaWidget()
+                    elif hasattr(field, "choices"):
+                        field.widget.choices = field.choices
+                    else:
+                        field.widget = widget()
+                    break
 
 
 class UnfoldChainedSelect(ChainedSelect):

--- a/src/bitcaster/utils/constance.py
+++ b/src/bitcaster/utils/constance.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 from django.forms import ChoiceField
+from unfold import forms
 
 from bitcaster.dispatchers.base import MessageProtocol
 from bitcaster.models import Channel
@@ -10,6 +11,8 @@ logger = logging.getLogger(__name__)
 
 
 class EmailChannel(ChoiceField):
+    widget = forms.UnfoldAdminSelectWidget
+
     def __init__(self, **kwargs: Any) -> None:
         ret = [
             (c["pk"], c["name"])
@@ -21,6 +24,8 @@ class EmailChannel(ChoiceField):
 
 
 class GroupSelect(ChoiceField):
+    widget = forms.UnfoldAdminSelectWidget
+
     def __init__(self, **kwargs: Any) -> None:
         from django.contrib.auth.models import Group
 

--- a/tests/admin/test_admin_constance.py
+++ b/tests/admin/test_admin_constance.py
@@ -1,12 +1,15 @@
 # mypy: disable-error-code="union-attr"
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
+from django.core.exceptions import ValidationError
 from django.test.client import RequestFactory
 from django.urls import reverse
 from django_webtest import DjangoTestApp
 from django_webtest.pytest_plugin import MixinWithInstanceVariables
 
+from bitcaster.admin.constance import CustomConstanceForm
 from bitcaster.state import state
 
 if TYPE_CHECKING:
@@ -35,3 +38,36 @@ def test_save_constance(app: DjangoTestApp, group: "Group", email_channel: "Chan
     res = app.get(url)
     res = res.forms["changelist-form"].submit()
     assert res.status_code == 302
+
+
+@patch("constance.forms.ConstanceForm.__init__", return_value=None)
+@patch("bitcaster.forms.unfold.UnfoldForm.__init__", return_value=None)
+def test_custom_constance_form_clean_valid(mock_unfold_init, mock_constance_init):
+    form = CustomConstanceForm()
+    form.cleaned_data = {
+        "OCCURRENCE_DEFAULT_RETENTION": 30,
+        "OCCURRENCE_MAX_RETENTION": 60,
+    }
+    # Should not raise
+    form.clean()
+
+
+@patch("constance.forms.ConstanceForm.__init__", return_value=None)
+@patch("bitcaster.forms.unfold.UnfoldForm.__init__", return_value=None)
+def test_custom_constance_form_clean_invalid(mock_unfold_init, mock_constance_init):
+    form = CustomConstanceForm()
+    form.cleaned_data = {
+        "OCCURRENCE_DEFAULT_RETENTION": 100,
+        "OCCURRENCE_MAX_RETENTION": 60,
+    }
+    with pytest.raises(ValidationError, match="Default retention cannot be greater than maximum retention."):
+        form.clean()
+
+
+@patch("constance.forms.ConstanceForm.__init__", return_value=None)
+@patch("bitcaster.forms.unfold.UnfoldForm.__init__", return_value=None)
+def test_custom_constance_form_clean_defaults(mock_unfold_init, mock_constance_init):
+    form = CustomConstanceForm()
+    form.cleaned_data = {}
+    # Should use defaults from constants and not raise
+    form.clean()


### PR DESCRIPTION
fix(admin): fix constance form rendering and validation

- Correct CustomConstanceForm inheritance to resolve TypeError.
- Skip widget overrides for HiddenInput to preserve 'version' field
- Use isinstance for field class checking in Unfold forms.
- Add validation and constants for occurrence retention.
- Explicitly set Unfold widgets for custom constance fields.

