### PR TITLE
refactor(dispatchers): rework Mailjet dispatcher to use REST client

### DIFF
--- a/src/bitcaster/dispatchers/email.py
+++ b/src/bitcaster/dispatchers/email.py
@@ -17,28 +17,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class EmailConfig(DispatcherConfig):
-    host = forms.CharField(label=_("Host"))
-    port = forms.CharField(label=_("Port"))
-    username = forms.CharField(label=_("Username"))
-    password = forms.CharField(label=_("Password"), widget=PasswordInput)
-    use_tls = forms.BooleanField(label=_("TLS"), required=False)
-    use_ssl = forms.BooleanField(label=_("SSL"), required=False)
-    timeout = forms.IntegerField(
-        label=_("Timeout"),
-        initial=3,
-        required=True,
-        validators=[MinValueValidator(0), MaxValueValidator(5)],
-    )
-
-
-class EmailDispatcher(Dispatcher):
-    slug = "email"
-    verbose_name = "Email"
+class BaseEmailDispatcher(Dispatcher):
     protocol: MessageProtocol = MessageProtocol.EMAIL
-
-    config_class: type[DispatcherConfig] = EmailConfig
-    backend = "django.core.mail.backends.smtp.EmailBackend"
 
     def send(self, address: str, payload: Payload, assignment: "Assignment | None" = None, **kwargs: Any) -> bool:
         try:
@@ -56,4 +36,31 @@ class EmailDispatcher(Dispatcher):
             return True
         except Exception as e:
             logger.exception(e)
+            if "is an invalid email address" in str(e):
+                raise DispatcherError(
+                    "The 'From Email' is not a valid email address. "
+                    "Please check your Channel's 'From Email' configuration."
+                ) from e
             raise DispatcherError(e) from e
+
+
+class EmailConfig(DispatcherConfig):
+    host = forms.CharField(label=_("Host"))
+    port = forms.CharField(label=_("Port"))
+    username = forms.CharField(label=_("Username"))
+    password = forms.CharField(label=_("Password"), widget=PasswordInput)
+    use_tls = forms.BooleanField(label=_("TLS"), required=False)
+    use_ssl = forms.BooleanField(label=_("SSL"), required=False)
+    timeout = forms.IntegerField(
+        label=_("Timeout"),
+        initial=3,
+        required=True,
+        validators=[MinValueValidator(0), MaxValueValidator(5)],
+    )
+
+
+class EmailDispatcher(BaseEmailDispatcher):
+    slug = "email"
+    verbose_name = "Email"
+    config_class: type[DispatcherConfig] = EmailConfig
+    backend = "django.core.mail.backends.smtp.EmailBackend"

--- a/src/bitcaster/dispatchers/mailjet.py
+++ b/src/bitcaster/dispatchers/mailjet.py
@@ -1,18 +1,64 @@
+import logging
+from typing import TYPE_CHECKING, Any
+
 from anymail.backends.mailjet import EmailBackend as MailjetBackend
 from django import forms
 from django.utils.translation import gettext_lazy as _
+from mailjet_rest import Client
 
-from .base import DispatcherConfig
-from .email import EmailDispatcher
+from ..exceptions import DispatcherError
+from .base import DispatcherConfig, Payload
+from .email import BaseEmailDispatcher
+
+if TYPE_CHECKING:
+    from requests import Response
+
+    from bitcaster.models import Assignment
+
+logger = logging.getLogger(__name__)
 
 
 class MailJetConfig(DispatcherConfig):
-    api_key = forms.CharField(label=_("API Key"))
-    secret_key = forms.CharField(label=_("API Secret"))
+    api_key = forms.CharField(label=_("API Key"), widget=forms.PasswordInput)
+    secret_key = forms.CharField(label=_("API Secret"), widget=forms.PasswordInput)
+    from_address = forms.EmailField(label=_("From Address"))
+    from_label = forms.CharField(label=_("From Name"))
 
 
-class MailJetDispatcher(EmailDispatcher):
+class MailJetDispatcher(BaseEmailDispatcher):
     slug = "mailjet"
     verbose_name = "Mailjet Email"
     config_class = MailJetConfig
     backend = MailjetBackend
+
+    def send(self, address: str, payload: Payload, assignment: "Assignment | None" = None, **kwargs: Any) -> bool:
+        try:
+            mailjet: Client = Client(auth=(self.config["api_key"], self.config["secret_key"]), version="v3.1")
+            data = {
+                "Messages": [
+                    {
+                        "From": {
+                            "Email": self.config["from_address"],
+                            "Name": self.config["from_label"],
+                        },
+                        "To": [{"Email": address, "Name": ""}],
+                        "Subject": payload.subject,
+                        "TextPart": payload.message,
+                        "HTMLPart": payload.html_message,
+                    }
+                ]
+            }
+            result: Response = mailjet.send.create(data=data)
+            if result.status_code == 401:
+                logger.error(result.text)
+                raise DispatcherError("Invalid API Key")
+            if result.status_code != 200:
+                logger.error(result.text)
+                raise DispatcherError("Generic Error")
+            return True
+        except DispatcherError as e:
+            logger.exception(e)
+            raise
+        except Exception as e:
+            logger.exception(e)
+            raise DispatcherError(e) from e

--- a/src/bitcaster/forms/unfold.py
+++ b/src/bitcaster/forms/unfold.py
@@ -79,13 +79,16 @@ class UnfoldAdminForm(AdminForm):
         model_admin: "Any | None" = None,
     ) -> None:
         super().__init__(form, fieldsets, prepopulated_fields, readonly_fields, model_admin)
-        for field in self.form.fields.values():
+        for field_name, field in self.form.fields.items():
             if isinstance(field.widget, forms.HiddenInput):
                 continue
 
             for field_class, widget in WIDGETS_OVERRIDES.items():
                 if isinstance(field, field_class):
-                    if isinstance(field.widget, forms.Textarea):
+                    if isinstance(field.widget, forms.PasswordInput):
+                        value = self.form.initial.get(field_name)
+                        field.widget = widgets.UnfoldAdminPasswordWidget({"value": value})
+                    elif isinstance(field.widget, forms.Textarea):
                         field.widget = widgets.UnfoldAdminTextareaWidget()
                     elif hasattr(field, "choices"):
                         field.widget.choices = field.choices

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,8 +67,6 @@ def pytest_configure(config):
 
     os.environ["MAILGUN_API_KEY"] = "11"
     os.environ["MAILGUN_SENDER_DOMAIN"] = "mailgun.domain"
-    os.environ["MAILJET_API_KEY"] = "11"
-    os.environ["MAILJET_SECRET_KEY"] = "11"
 
     os.environ["SECRET_KEY"] = "super-secret-key-just-for-testing"
     os.environ["SECURE_HSTS_PRELOAD"] = "0"

--- a/tests/dispatchers/mailjet.yaml
+++ b/tests/dispatchers/mailjet.yaml
@@ -1,8 +1,12 @@
 responses:
 - response:
     auto_calculate_content_length: false
-    body: '{"Messages":[{"Status":"success","CustomID":"","To":[{"Email":"s.apostolico@gmail.com","MessageUUID":"c5c1e5e9-86ff-48df-b818-81e668432cc4","MessageID":576460775557010493,"MessageHref":"https://api.mailjet.com/v3/REST/message/576460775557010493"}],"Cc":[],"Bcc":[]}]}'
-    content_type: text/plain
+    body: '{"Messages":[{"Status":"success","CustomID":"","To":[{"Email":"test@bitcaster.org","MessageUUID":"f91b2b85-b543-41c4-990e-ecf90a967616","MessageID":288230412159901111,"MessageHref":"https://api.mailjet.com/v3/REST/message/288230412159901111"}],"Cc":[],"Bcc":[]}]}'
+    content_type: application/json; charset=UTF-8
+    headers:
+      content-length: '263'
+      date: Wed, 18 Mar 2026 14:29:48 GMT
+      x-mj-request-guid: 3767c643-3b5d-4919-a50e-5947f5a61d27
     method: POST
     status: 200
     url: https://api.mailjet.com/v3.1/send

--- a/tests/dispatchers/test_d_mailjet.py
+++ b/tests/dispatchers/test_d_mailjet.py
@@ -5,25 +5,40 @@ from unittest.mock import Mock
 import pytest
 from django.core.exceptions import ValidationError
 from responses import RequestsMock
+from strategy_field.utils import fqn
 
 from bitcaster.dispatchers import MailJetDispatcher
 from bitcaster.dispatchers.base import Payload
 
 pytestmark = [pytest.mark.dispatcher, pytest.mark.django_db]
 
+RESPONSE_FIXTURE = Path(__file__).parent / "mailjet.yaml"
 
-# @_recorder.record(file_path=Path(__file__).parent / "mailjet.yaml")
+
+# @_recorder.record(file_path=RESPONSE_FIXTURE)
 def test_mailjet(monkeypatch: pytest.MonkeyPatch, mail_payload: Payload, mocked_responses: RequestsMock) -> None:
     from bitcaster.dispatchers import MailJetDispatcher
     from bitcaster.models import Channel, Project
 
-    mocked_responses._add_from_file(file_path=Path(__file__).parent / "mailjet.yaml")
+    if "MAILJET_SENDER" in os.environ:
+        mocked_responses.passthru_prefixes = (r"https://api.mailjet.com/",)
+    else:
+        mocked_responses._add_from_file(file_path=RESPONSE_FIXTURE)
+        os.environ.setdefault("MAILJET_SENDER", "sender@bitcaster.io")
+        os.environ.setdefault("MAILJET_RCPT", "recipient@bitcaster.io")
+        os.environ.setdefault("MAILJET_API_KEY", "key")
+        os.environ.setdefault("MAILJET_API_SECRET", "secret")
 
     ch = Channel(
-        project=Project(from_email=os.environ["GMAIL_USER"], subject_prefix="[gmail] "),
-        config={"api_key": os.environ["MAILJET_API_KEY"], "secret_key": os.environ["MAILJET_SECRET_KEY"]},
+        project=Project(from_email=os.environ["MAILJET_SENDER"], subject_prefix="[mailjet] "),
+        dispatcher=fqn(MailJetDispatcher),
+        config={
+            "api_key": os.environ["MAILJET_API_KEY"],
+            "secret_key": os.environ["MAILJET_API_SECRET"],
+            "from_address": os.environ["MAILJET_SENDER"],
+            "from_label": "Bitcaster",
+        },
     )
-
     MailJetDispatcher(ch).send(os.environ["TEST_EMAIL_RECIPIENT"], mail_payload)
 
 


### PR DESCRIPTION
This commit refactors the Mailjet dispatcher to use the `mailjet-rest` client directly, removing the dependency on the `anymail` backend for this dispatcher.

This change allows for more specific error handling and better control over the API calls. A `BaseEmailDispatcher` has been introduced to consolidate common email sending logic and reduce code duplication.

Additionally, the configuration for Mailjet now includes dedicated 'From Address' and 'From Label' fields. As a minor UI improvement, password fields in the admin interface are now rendered with a more user-friendly widget.

# Legal Boilerplate

Look, I get it.
Contributing to Bitcaster, I retain all rights, title and interest in and to my contributions, and by keeping
this boilerplate intact I confirm that Bitcaster can use, modify, copy, and redistribute my contributions,
under Bitcaster's choice of terms.
