### PR TITLE
chore(ci): update dockerize and release workflows

### DIFF
--- a/.github/workflows/dockerize.yml
+++ b/.github/workflows/dockerize.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - '**'  # Trigger on push to any branch
+    tags:
+      - '*'    # Trigger on push to any tag
   workflow_dispatch:
     inputs:
       git_reference:
@@ -137,7 +139,7 @@ jobs:
           push: true
           tags: |
             os4d/bitcaster:${{ steps.config.outputs.tag }}
-            ${{ github.event.inputs.latest == 'true' && 'os4d/bitcaster:latest' || null}}
+            ${{ github.event.inputs.latest == 'true' && 'os4d/bitcaster:latest' || null }}
           build-args: |
             VERSION=${{ steps.config.outputs.version }}
             BUILD_DATE=${{ steps.config.outputs.build_date }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release to PyPI
 on:
-  push:
-    tags: ["*"]
+  release:
+    types: [published]
 
 env:
   dists-artifact-name: python-package-distributions
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
@@ -33,12 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: release
-      url: https://pypi.org/project/${{ github.reppository }}/${{ github.ref_name }}
+      url: https://pypi.org/project/bitcaster/${{ github.ref_name }}
     permissions:
       id-token: write
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.dists-artifact-name }}
           path: dist/
@@ -46,15 +46,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           attestations: true
-  dockerize:
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - name: Trigger dockerize workflow
-        run: |
-          curl -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            https://api.github.com/repos/${{ github.repository }}/actions/workflows/dockerize.yml/dispatches \
-            -d "{\"ref\":\"refs/tags/${{ github.ref_name }}\", \"inputs\": {\"version\": \"${{ github.ref_name }}\"}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,6 +47,9 @@ RUN pip install uwsgi uv
 
 # ------- builder -------
 FROM deps AS builder
+ARG VERSION
+ARG GIT_SHA
+ARG BUILD_DATE
 ENV VIRTUAL_ENV=/venv \
     UV_PROJECT_ENVIRONMENT=/venv \
     HATCH_VCS_VERSION=${VERSION}
@@ -69,6 +72,9 @@ RUN uv venv --no-cache $VIRTUAL_ENV \
     && uv build
 
 FROM base_os AS dist
+ARG VERSION
+ARG GIT_SHA
+ARG BUILD_DATE
 ADD docker/conf /conf/
 ADD docker/bin/* /usr/local/bin/
 


### PR DESCRIPTION
  Description
  This pull request improves the reliability and integration of our CI/CD pipelines by updating the Docker build process and the PyPI release workflow. The primary focus is on standardizing build metadata and
  streamlining the release trigger mechanism.

  Key Changes
   - CI Workflows:
     - Dockerize: Added tag-based triggers (tags: '*') to the Docker build workflow to ensure images are built automatically on new releases. Fixed a formatting issue in the latest tag logic.
     - Release: Switched the trigger from push: tags to release: published for more controlled PyPI deployments.
     - Dependency Updates: Updated astral-sh/setup-uv to v6 and actions/download-artifact to v4.
     - Cleanup: Removed the manual dockerize trigger from the release workflow, as it is now handled natively via tag triggers in dockerize.yml.
     - Fix: Corrected the PyPI project URL and a typo in the environment configuration (github.reppository -> bitcaster).

   - Docker:
     - Added build-time arguments (ARG VERSION, ARG GIT_SHA, ARG BUILD_DATE) to the Dockerfile in both builder and dist stages to properly handle build metadata and versioning during the build process.


# Legal Boilerplate

Look, I get it.
Contributing to Bitcaster, I retain all rights, title and interest in and to my contributions, and by keeping
this boilerplate intact I confirm that Bitcaster can use, modify, copy, and redistribute my contributions,
under Bitcaster's choice of terms.
