### PR TITLE
improve BackgroundManager singleton, stale runner cleanup, and monitor error handling

### DIFF
--- a/src/bitcaster/cli/worker.py
+++ b/src/bitcaster/cli/worker.py
@@ -15,18 +15,13 @@ def runit(args: list[str], log_level, comp_log_level, **extra) -> None:
 
     from bitcaster.cli.utils import configure_logging
     from bitcaster.runner.config import dramatiq
-    from bitcaster.runner.manager import BackgroundManager
 
-    manager = BackgroundManager()
-    manager.register_runner()
     click.echo(" ".join(args))
     try:
         configure_logging(log_level, comp_log_level)
         dramatiq.cli.main(make_argument_parser().parse_args(args))  # type: ignore[no-untyped-call]
     except KeyboardInterrupt:
         click.echo("Runner stopping...")
-    finally:
-        manager.unregister_runner()
 
 
 @click.command()

--- a/src/bitcaster/runner/manager.py
+++ b/src/bitcaster/runner/manager.py
@@ -20,9 +20,19 @@ if TYPE_CHECKING:
 
 
 class BackgroundManager:
+    _instance: "BackgroundManager | None" = None
+
+    def __new__(cls) -> "BackgroundManager":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
     def __init__(self) -> None:
+        if hasattr(self, "_initialized"):
+            return
+        self._initialized = True
         self.client = get_redis_connection("default")
-        self.name = f"bitcaster@{gethostname()}"
+        self.name = f"bitcaster@{gethostname()}({os.getpid()})"
         self._actors: Iterable[Actor[Any, Any]] = []
 
     @property
@@ -59,7 +69,7 @@ class BackgroundManager:
             elif key_type == "hash":
                 sizes[queue] = broker.client.hlen(key)
             else:
-                sizes[queue] = 0  # unknown type
+                sizes[queue] = 0
 
         return sizes
 
@@ -73,7 +83,6 @@ class BackgroundManager:
                 if key_type == "list":
                     raw_messages = broker.client.lrange(key, 0, -1)
                     for raw in raw_messages:
-                        # If list uses msgpack
                         msg = msgpack.unpackb(raw, raw=False)
                         items.append(msg)
                 elif key_type == "hash":
@@ -98,39 +107,56 @@ class BackgroundManager:
     def register_runner(self) -> None:
         logger.debug(f"Registering runner {self.name}")
         self.client.sadd("background:runners", self.name)
-        return self.client.set(f"background:runner:{self.name}:last_seen", datetime.now(UTC).timestamp())
+        self.client.set(f"background:runners:{self.name}:last_seen", datetime.now(UTC).timestamp())
 
-    def unregister_runner(self) -> None:
-        logger.debug(f"Unregistering runner {self.name}")
-        self.client.srem("background:runners", self.name)
-        self.client.delete(f"background:runners:{self.name}:tasks")
-        return self.client.delete(f"background:runners:{self.name}:last_seen")
+    def unregister_runner(self, name: str | None = None) -> None:
+        target = name or self.name
+        logger.debug(f"Unregistering runner {target}")
+        self.client.srem("background:runners", target)
+        self.client.delete(f"background:runners:{target}:tasks")
+        self.client.delete(f"background:runners:{target}:last_seen")
 
     def get_runners(self, quick: bool = False) -> dict[str, Any]:
         items = self.client.smembers("background:runners")
         ret = {}
+        stale_runners = []
         for e in items:
-            ts = float(self.client.get(f"background:runner:{e.decode()}:last_seen").decode())
+            runner_name = e.decode()
+            raw_ts = self.client.get(f"background:runners:{runner_name}:last_seen")
+            if raw_ts is None:
+                logger.debug(f"Runner {runner_name} has no last_seen, marking as stale")
+                stale_runners.append(runner_name)
+                continue
+
+            ts = float(raw_ts.decode())
             dt = datetime.fromtimestamp(ts, tz=UTC)
-            tasks = self.client.hgetall(f"background:runners:{e.decode()}:tasks")
-            if alive := (datetime.now(UTC) - dt < timedelta(minutes=2)):
-                ret[e.decode()] = {
-                    "tasks": sorted([json.loads(v.decode()) for k, v in tasks.items()], key=lambda t: t["pid"]),
-                    "last_seen": dt.strftime("%Y-%m-%d %H:%M:%S"),
-                    "alive": alive,
-                }
+            tasks = self.client.hgetall(f"background:runners:{runner_name}:tasks")
+            alive = datetime.now(UTC) - dt < timedelta(minutes=2)
+            ret[runner_name] = {
+                "tasks": sorted([json.loads(v.decode()) for k, v in tasks.items()], key=lambda t: t["pid"]),
+                "last_seen": dt.strftime("%Y-%m-%d %H:%M:%S"),
+                "alive": alive,
+            }
+            if datetime.now(UTC) - dt > timedelta(hours=1):
+                logger.debug(f"Unregistering stale runner {runner_name}")
+                stale_runners.append(runner_name)
+
+        for stale in stale_runners:
+            self.unregister_runner(stale)
         return ret
 
     def update_task(self, actor_name: str) -> None:
-        self.client.set(f"background:runner:{actor_name}:last_run", datetime.now(UTC).timestamp())
+        self.client.set(f"background:runners:{self.name}:{actor_name}:last_run", datetime.now(UTC).timestamp())
 
     def get_task_last_run(self, actor_name: str) -> datetime | None:
         try:
-            ts = float(self.client.get(f"background:runner:{actor_name}:last_run").decode())
-            dt = datetime.fromtimestamp(ts, tz=UTC)
-        except (TypeError, AttributeError):
-            dt = None
-        return dt
+            raw_ts = self.client.get(f"background:runners:{self.name}:{actor_name}:last_run")
+            if raw_ts is None:
+                return None
+            ts = float(raw_ts.decode())
+            return datetime.fromtimestamp(ts, tz=UTC)
+        except (TypeError, ValueError, AttributeError):
+            return None
 
     def register_task(self, message: "MessageProxy") -> None:
         self.register_runner()
@@ -175,9 +201,12 @@ def init_scheduler() -> None:
     for sid, config in SCHEDULER.items():
         job_args = {k: v for k, v in config.items() if k in ["func", "trigger", "replace_existing", "args", "kwargs"]}
         trigger_args = {k: v for k, v in config.items() if k not in job_args}
-        __, created = Task.objects.get_or_create(
-            slug=sid, defaults={"name": sid, "trigger_config": trigger_args, **job_args}
-        )
+        defaults = {"name": sid, "trigger_config": trigger_args, **job_args}
+        task, created = Task.objects.get_or_create(slug=sid, defaults=defaults)
+        if not created:
+            for key, value in defaults.items():
+                setattr(task, key, value)
+            task.save(update_fields=list(defaults.keys()))
 
 
 scheduler = BlockingScheduler()

--- a/src/bitcaster/runner/middlewares.py
+++ b/src/bitcaster/runner/middlewares.py
@@ -10,20 +10,14 @@ from bitcaster.runner.manager import BackgroundManager
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from dramatiq import Actor, Broker, Message, MessageProxy
+    from dramatiq import Actor, Broker, MessageProxy
 
 
 class WorkerHeartbeatMiddleware(Middleware):
     def before_process_message(self, broker: "Broker", message: "MessageProxy") -> None:
-        logger.debug(f"START {message.actor_name} {message, type(message)}")
-        from .manager import BackgroundManager
-
+        logger.debug(f"START {message.actor_name}")
         message.options["started_at"] = int(time.time() * 1000)
-        manager = BackgroundManager()
-        try:
-            manager.register_task(message)
-        except Exception:
-            raise
+        BackgroundManager().register_task(message)
 
     def after_process_message(
         self,
@@ -33,15 +27,8 @@ class WorkerHeartbeatMiddleware(Middleware):
         result: Any | None = None,
         exception: BaseException | None = None,
     ) -> None:
-        logger.debug(f"END {message.actor_name} {message, type(message)}")
-        from .manager import BackgroundManager
-
-        manager = BackgroundManager()
-
-        try:
-            manager.unregister_task(message)
-        except Exception:
-            raise
+        logger.debug(f"END {message.actor_name}")
+        BackgroundManager().unregister_task(message)
 
 
 class DbConnectionsMiddleware(Middleware):
@@ -68,8 +55,7 @@ class ClickMiddleware(Middleware):
         pass
 
     def after_worker_boot(self, broker: "Broker", worker: "Worker") -> None:
-        manager = BackgroundManager()
-        manager.register_runner()
+        BackgroundManager().register_runner()
 
     def before_enqueue(self, broker: "Broker", message: "Message[Any]", delay: int) -> None:
         pass
@@ -90,8 +76,8 @@ class ClickMiddleware(Middleware):
     ) -> None:
         delta = time.perf_counter() - message.options["start"]
         actor: "Actor[Any, Any]" = broker.get_actor(message.actor_name)
-        logging = message.options.get("logging") or actor.options.get("logging")
-        if logging:
+        do_logging = message.options.get("logging") or actor.options.get("logging")
+        if do_logging:
             from bitcaster.models import ProcessLogEntry
 
             ProcessLogEntry.objects.log_process(

--- a/src/bitcaster/runner/tasks.py
+++ b/src/bitcaster/runner/tasks.py
@@ -122,10 +122,10 @@ def monitor_check(pk: int) -> str:
     from django.contrib.contenttypes.models import ContentType
 
     try:
-        monitor: "Monitor" = Monitor.objects.get(pk=pk)
+        monitor: "Monitor" = Monitor.objects.get(active=True, pk=pk)
     except Monitor.DoesNotExist as e:
         logger.exception(e)
-        raise
+        return "Monitor not found or deactivated"
 
     try:
         if monitor.active:
@@ -145,6 +145,14 @@ def monitor_check(pk: int) -> str:
         logger.exception(e)
         monitor.active = False
         monitor.result = {"error": str(e)}
+        LogEntry.objects.create(
+            content_type=ContentType.objects.get_for_model(Monitor),
+            object_id=monitor.pk,
+            action_flag=200,
+            user=bitcaster.system_user,
+            object_repr=str(monitor),
+            change_message=f"Monitor failed: {e}",
+        )
         raise
     finally:
         monitor.save()

--- a/tests/runner/test_runner_manager.py
+++ b/tests/runner/test_runner_manager.py
@@ -118,9 +118,160 @@ def test_manager_actors(manager: "BackgroundManager", message):
 def test_manager_get_queue_sizes(manager: "BackgroundManager", message):
     from bitcaster.runner.broker import broker
 
+    manager._actors = []
     with mock.patch.object(broker, "get_declared_actors", wraps=broker.get_declared_actors) as m:
         assert manager.actors
         assert m.call_count == 1
+
     with mock.patch.object(broker, "get_declared_actors", wraps=broker.get_declared_actors) as m:
         assert manager.actors
         assert m.call_count == 0
+
+
+@pytest.mark.xdist_group(name="runner")
+def test_get_queue_sizes_unknown_key_type(manager: "BackgroundManager", broker):
+    @dramatiq.actor
+    def test_unknown_type():
+        pass
+
+    queue_key = f"{broker.namespace}:default.msgs"
+    broker.client.delete(queue_key)
+    broker.client.set(queue_key, "dummy")
+    result = manager.get_queue_sizes()
+    assert result == {"default": 0}
+
+
+@pytest.mark.xdist_group(name="runner")
+def test_get_queued_items_list_type(manager: "BackgroundManager", broker):
+    @dramatiq.actor
+    def test_list_items():
+        pass
+
+    test_list_items.send()
+    items = manager.get_queued_items()
+    assert len(items) == 1
+    assert items[0]["actor_name"] == "test_list_items"
+
+
+@pytest.mark.xdist_group(name="runner")
+def test_get_queued_items_no_key(manager: "BackgroundManager", broker):
+    @dramatiq.actor
+    def test_no_key():
+        pass
+
+    items = manager.get_queued_items()
+    assert items == []
+
+
+@pytest.mark.xdist_group(name="runner")
+def test_get_runners_stale_no_last_seen(manager: "BackgroundManager"):
+    stale_name = "stale_runner_no_ts"
+    manager.client.sadd("background:runners", stale_name)
+    runners = manager.get_runners()
+    assert stale_name not in runners
+    assert stale_name not in manager.client.smembers("background:runners")
+
+
+@pytest.mark.xdist_group(name="runner")
+def test_get_runners_stale_over_one_hour(manager: "BackgroundManager"):
+    from datetime import UTC, datetime, timedelta
+
+    stale_name = "stale_runner_old"
+    old_ts = (datetime.now(UTC) - timedelta(hours=2)).timestamp()
+    manager.client.sadd("background:runners", stale_name)
+    manager.client.set(f"background:runners:{stale_name}:last_seen", old_ts)
+    runners = manager.get_runners()
+    assert stale_name in runners
+    assert runners[stale_name]["alive"] is False
+    assert stale_name not in manager.client.smembers("background:runners")
+
+
+@pytest.mark.xdist_group(name="runner")
+def test_get_task_last_run_missing(manager: "BackgroundManager"):
+    result = manager.get_task_last_run("nonexistent_actor")
+    assert result is None
+
+
+@pytest.mark.xdist_group(name="runner")
+def test_get_task_last_run_success(manager: "BackgroundManager"):
+    from datetime import UTC, datetime
+
+    actor = "test_actor_success"
+    now = datetime.now(UTC)
+    manager.client.set(f"background:runners:{manager.name}:{actor}:last_run", now.timestamp())
+    result = manager.get_task_last_run(actor)
+    assert result is not None
+    assert abs((result - now).total_seconds()) < 1
+
+
+@pytest.mark.xdist_group(name="runner")
+def test_get_task_last_run_invalid_data(manager: "BackgroundManager"):
+    manager.client.set(f"background:runners:{manager.name}:nonexistent_actor:last_run", b"not_a_number")
+    result = manager.get_task_last_run("nonexistent_actor")
+    assert result is None
+
+
+@pytest.mark.xdist_group(name="runner")
+def test_get_task_last_run_none_value(manager: "BackgroundManager"):
+    """Test when Redis returns None for the key."""
+    manager.client.delete(f"background:runners:{manager.name}:missing_actor:last_run")
+    result = manager.get_task_last_run("missing_actor")
+    assert result is None
+
+
+@pytest.mark.xdist_group(name="runner")
+def test_init_scheduler_updates_existing(broker, settings):
+    from bitcaster.models import Task
+    from bitcaster.runner.manager import SCHEDULER, init_scheduler
+
+    Task.objects.all().delete()
+    sid = "scan_occurrences"
+    config = SCHEDULER[sid]
+
+    task = Task.objects.create(slug=sid, name="old_name", trigger_config={}, func="old.func", trigger="interval")
+    init_scheduler()
+    task.refresh_from_db()
+    assert task.func == config["func"]
+    assert task.trigger == config["trigger"]
+
+
+@pytest.mark.xdist_group(name="runner")
+def test_init_scheduler_creates_new(broker, settings):
+    from bitcaster.models import Task
+    from bitcaster.runner.manager import SCHEDULER, init_scheduler
+
+    Task.objects.all().delete()
+    sid = "scan_occurrences"
+    init_scheduler()
+    task = Task.objects.get(slug=sid)
+    assert task.name == sid
+    assert task.func == SCHEDULER[sid]["func"]
+
+
+@pytest.mark.xdist_group(name="runner")
+def test_get_all_tasks(manager: "BackgroundManager"):
+    all_tasks = manager.get_all_tasks()
+    assert isinstance(all_tasks, dict)
+    assert len(all_tasks) > 0
+
+
+@pytest.mark.xdist_group(name="runner")
+def test_update_task(manager: "BackgroundManager", message):
+    manager.update_task(message.actor_name)
+    key = f"background:runners:{manager.name}:{message.actor_name}:last_run"
+    assert manager.client.exists(key)
+
+
+@pytest.mark.xdist_group(name="runner")
+def test_reset_with_keys(manager: "BackgroundManager"):
+    manager.client.set("background:test_key", "value")
+    manager.reset()
+    assert not manager.client.exists("background:test_key")
+
+
+@pytest.mark.xdist_group(name="runner")
+def test_scheduler_info_no_ping(manager: "BackgroundManager"):
+    manager.client.delete("scheduler:alive")
+    info = manager.scheduler_info()
+    assert info["status"] is False
+    assert info["seen"] == ""

--- a/tests/runner/test_runner_tasks.py
+++ b/tests/runner/test_runner_tasks.py
@@ -120,19 +120,6 @@ def test_monitor_check_success(monitor):
             ).exists()
 
 
-def test_monitor_check_inactive():
-    m = MonitorFactory(active=False)
-    res = monitor_check(m.pk)
-    assert res == "inactive"
-
-
-def test_monitor_check_not_found():
-    from bitcaster.models import Monitor
-
-    with pytest.raises(Monitor.DoesNotExist):
-        monitor_check(9999)
-
-
 def test_monitor_check_error():
     m = MonitorFactory(active=True)
     with patch.object(XAgent, "check", side_effect=Exception("Agent error")):
@@ -141,6 +128,11 @@ def test_monitor_check_error():
         m.refresh_from_db()
         assert m.active is False
         assert "Agent error" in m.result["error"]
+
+
+def test_monitor_check_monitor_not_found():
+    result = monitor_check(99999)
+    assert result == "Monitor not found or deactivated"
 
 
 def test_check_for_new_user_messages_no_users():

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3,9 +3,9 @@ from typing import TYPE_CHECKING, Any, TypedDict
 from unittest.mock import Mock, patch
 
 import pytest
-from django.core.exceptions import ObjectDoesNotExist
 from strategy_field.utils import fqn
 from testutils.dispatcher import XDispatcher
+from testutils.factories import MonitorFactory
 from testutils.perms import configure_model
 
 from bitcaster.constants import SystemEvent, bitcaster
@@ -75,6 +75,11 @@ def setup(admin_user: "User") -> "Context":
         "notification": no,
         "silent_event": EventFactory.create(application__name="External"),
     }
+
+
+@pytest.fixture
+def monitor() -> "Monitor":
+    return MonitorFactory.create()
 
 
 @pytest.mark.django_db(transaction=True)
@@ -443,17 +448,13 @@ def test_monitor_run(system_user: "User", monitor) -> None:
         assert mock_send.call_count == 1
 
 
-def test_monitor_check(system_user: "User") -> None:
-    from testutils.factories.monitor import MonitorFactory
+def test_monitor_check(system_user: "User", monitor) -> None:
+    assert monitor_check("-1") == "Monitor not found or deactivated"
 
-    with pytest.raises(ObjectDoesNotExist):
-        monitor_check("-1")
-
-    monitor = MonitorFactory.create()
     assert monitor_check(monitor.pk) == "done"
 
     with configure_model(monitor, active=False):
-        assert monitor_check(monitor.pk) == "inactive"
+        assert monitor_check(monitor.pk) == "Monitor not found or deactivated"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION

- Make BackgroundManager a proper singleton with new and _initialized guard
- Add PID to runner name for multi-process identification
- Fix Redis key naming consistency (runner → runners)
- Add stale runner cleanup in get_runners (>1 hour without heartbeat)
- Handle missing last_seen timestamp gracefully
- Return early instead of raising when monitor not found in monitor_check
- Log monitor failures to LogEntry
- Clean up middleware error handling and logging
- Remove redundant manager register/unregister from CLI worker
- Update init_scheduler to sync existing task configs`

# Legal Boilerplate

Look, I get it.
Contributing to Bitcaster, I retain all rights, title and interest in and to my contributions, and by keeping
this boilerplate intact I confirm that Bitcaster can use, modify, copy, and redistribute my contributions,
under Bitcaster's choice of terms.
