### PR TITLE
feat: add X (Twitter) dispatcher

### DIFF
--- a/.ai/dispatchers.md
+++ b/.ai/dispatchers.md
@@ -15,8 +15,14 @@ This guide covers the creation and configuration of new Dispatchers (SMS, Webhoo
 ### 1. Dispatcher Class Structure
 ```python
 from typing import Any
-from .base import Dispatcher, MessageProtocol, Payload
+from django import forms
+from .base import Dispatcher, MessageProtocol, Payload, DispatcherConfig
 from ..exceptions import DispatcherError
+
+
+class MyDispatcherConfig(DispatcherConfig):
+    key = forms.CharField()
+
 
 class MyDispatcher(Dispatcher):
     slug = "my-dispatcher"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Bitcaster is a system-to-user notification platform. For detailed guidance, refe
 
 1. **[.ai/standards.md](.ai/standards.md):** Environment setup, Python/Django conventions, linting, and type safety rules.
 2. **[.ai/architecture.md](.ai/architecture.md):** Project layout, code structure, and import patterns.
-3. **[.ai/workflow.md](.ai/workflow.md):** Build/verify commands, CI rules, and validation protocols.
+3. **[.ai/workflow.md](.ai/workflow.md):** Coding rules.
 4. **[.ai/safety.md](.ai/safety.md):** Secret management, git safety, and data privacy rules.
 5. **[.ai/testing-patterns.md](.ai/testing-patterns.md):** Test factories, fixtures, markers, and coverage rules.
 6. **[.ai/dispatchers.md](.ai/dispatchers.md):** Dispatcher implementation and testing guidelines.

--- a/docs/adm-guide/dispatchers/.pages
+++ b/docs/adm-guide/dispatchers/.pages
@@ -9,3 +9,4 @@ dispatchers:
     - sys.md
     - teams.md
     - twilio.md
+    - x.md

--- a/docs/adm-guide/dispatchers/x.md
+++ b/docs/adm-guide/dispatchers/x.md
@@ -1,0 +1,33 @@
+# X (Twitter) Dispatcher
+
+The X dispatcher posts notifications as tweets to the configured X account via the X API v2.
+
+## Prerequisites
+
+1. An X Developer account at [developer.x.com](https://developer.x.com)
+2. A Project with an App configured with **OAuth 1.0a** and the Access Token set to **Read and Write** permissions
+
+## Configuration
+
+The following parameters are required to configure the X dispatcher. They are found in your X App's **Keys & Tokens** page under **OAuth 1.0 Keys**:
+
+| Field | Where to find it |
+|---|---|
+| **Consumer Key** | Visible directly in the OAuth 1.0 Keys section. |
+| **Consumer Key Secret** | Click **Show** next to the Consumer Key. |
+| **Access Token** | Visible directly in the OAuth 1.0 Keys section. |
+| **Access Token Secret** | Click **Show** next to the Access Token. |
+
+## How to use
+
+1. Open your X App at [developer.x.com](https://developer.x.com) and go to the **Keys & Tokens** page.
+2. Under **OAuth 1.0 Keys**, copy the **Consumer Key** and click **Show** to copy the **Consumer Key Secret**.
+3. Copy the **Access Token** and click **Show** to copy the **Access Token Secret**.
+4. Ensure the token has **Read and Write** permissions under **User authentication settings**.
+5. In Bitcaster, select `X (Twitter)` as the dispatcher for a Channel.
+6. Click the **Configure** button on the Channel admin page.
+7. Fill in all four fields: Consumer Key, Consumer Key Secret, Access Token, Access Token Secret.
+8. Save the Channel configuration.
+
+!!! note
+    Messages are truncated to 280 characters to comply with X post limits.

--- a/src/bitcaster/dispatchers/__init__.py
+++ b/src/bitcaster/dispatchers/__init__.py
@@ -9,6 +9,7 @@ from .sys import SystemDispatcher
 from .teams import TeamsDispatcher
 from .twilio import TwilioSMS
 from .user_message import UserMessageDispatcher
+from .x import XDispatcher
 
 __all__ = [
     "LocalDatabaseDispatcher",
@@ -22,4 +23,5 @@ __all__ = [
     "TeamsDispatcher",
     "TwilioSMS",
     "UserMessageDispatcher",
+    "XDispatcher",
 ]

--- a/src/bitcaster/dispatchers/x.py
+++ b/src/bitcaster/dispatchers/x.py
@@ -1,0 +1,61 @@
+from typing import TYPE_CHECKING, Any
+
+import logging
+
+from requests_oauthlib import OAuth1Session
+
+from django import forms
+from django.utils.translation import gettext_lazy as _
+
+from .base import Dispatcher, DispatcherConfig, MessageProtocol, Payload
+from ..exceptions import DispatcherError
+
+if TYPE_CHECKING:
+    from ..models import Assignment
+
+logger = logging.getLogger(__name__)
+
+
+class XConfig(DispatcherConfig):
+    consumer_key = forms.CharField(label=_("Consumer Key"))
+    consumer_key_secret = forms.CharField(label=_("Consumer Key Secret"))
+    access_token = forms.CharField(label=_("Access Token"))
+    access_token_secret = forms.CharField(label=_("Access Token Secret"))
+
+
+class XDispatcher(Dispatcher):
+    id = 500
+    slug = "x"
+    verbose_name = "X (Twitter)"
+    config_class = XConfig
+    protocol = MessageProtocol.PLAINTEXT
+
+    MAX_CHARS = 280
+
+    def _send(self, address: str, payload: Payload, assignment: "Assignment | None" = None, **kwargs: Any) -> bool:
+        text = payload.message[: self.MAX_CHARS]
+
+        session = OAuth1Session(
+            client_key=self.config["consumer_key"],
+            client_secret=self.config["consumer_key_secret"],
+            resource_owner_key=self.config["access_token"],
+            resource_owner_secret=self.config["access_token_secret"],
+        )
+        response = session.post("https://api.twitter.com/2/tweets", json={"text": text})
+
+        if response.status_code not in (200, 201):
+            logger.error(f"X dispatcher error: {response.status_code} - {response.text}")
+            raise DispatcherError(f"Failed to post to X: {response.text}")
+
+        return True
+
+    def get_extra_config_info(self) -> str:
+        return (
+            "Messages are truncated to 280 characters. "
+            'Go to your App\'s <a href="https://developer.x.com" target="_blank">Keys &amp; Tokens</a> page, '
+            "copy the Consumer Key and Consumer Key Secret from <strong>OAuth 1.0 Keys</strong>, "
+            "then click <strong>Show</strong> on the Access Token to reveal the "
+            "Access Token and Access Token Secret. "
+            "Ensure the token has <strong>Read and Write</strong> permissions "
+            'under "User authentication settings".'
+        )

--- a/tests/dispatchers/test_d_x.py
+++ b/tests/dispatchers/test_d_x.py
@@ -1,0 +1,108 @@
+import requests
+
+import pytest
+from unittest.mock import patch
+
+from strategy_field.utils import fqn
+
+from bitcaster.dispatchers import XDispatcher
+from bitcaster.exceptions import DispatcherError
+from bitcaster.models import Channel
+
+pytestmark = [pytest.mark.dispatcher, pytest.mark.django_db]
+
+
+def test_x_send_success(mail_payload: requests.Response) -> None:
+    ch = Channel(
+        dispatcher=fqn(XDispatcher),
+        config={
+            "consumer_key": "key",
+            "consumer_key_secret": "secret",
+            "access_token": "token",
+            "access_token_secret": "token_secret",
+        },
+    )
+    with patch("requests_oauthlib.OAuth1Session.post") as mock_post:
+        mock_response = requests.Response()
+        mock_response.status_code = 201
+        mock_response._content = b'{"data": {"id": "123", "text": "Hello"}}'
+        mock_post.return_value = mock_response
+
+        assert XDispatcher(ch).send("ignored", mail_payload)
+        mock_post.assert_called_once_with("https://api.twitter.com/2/tweets", json={"text": "message"})
+
+
+def test_x_send_failure(mail_payload: requests.Response) -> None:
+    ch = Channel(
+        dispatcher=fqn(XDispatcher),
+        config={
+            "consumer_key": "key",
+            "consumer_key_secret": "secret",
+            "access_token": "token",
+            "access_token_secret": "token_secret",
+        },
+    )
+    with patch("requests_oauthlib.OAuth1Session.post") as mock_post:
+        mock_response = requests.Response()
+        mock_response.status_code = 403
+        mock_response._content = b'{"errors": [{"message": "Forbidden"}]}'
+        mock_post.return_value = mock_response
+
+        with pytest.raises(DispatcherError, match="Failed to post to X"):
+            XDispatcher(ch).send("ignored", mail_payload)
+
+
+def test_x_send_network_error(mail_payload: requests.Response) -> None:
+    ch = Channel(
+        dispatcher=fqn(XDispatcher),
+        config={
+            "consumer_key": "key",
+            "consumer_key_secret": "secret",
+            "access_token": "token",
+            "access_token_secret": "token_secret",
+        },
+    )
+    with patch("requests_oauthlib.OAuth1Session.post") as mock_post:
+        mock_post.side_effect = requests.ConnectionError("Timeout")
+
+        with pytest.raises(DispatcherError, match="Error sending message"):
+            XDispatcher(ch).send("ignored", mail_payload)
+
+
+def test_x_truncates_long_message(mail_payload: requests.Response) -> None:
+    ch = Channel(
+        dispatcher=fqn(XDispatcher),
+        config={
+            "consumer_key": "key",
+            "consumer_key_secret": "secret",
+            "access_token": "token",
+            "access_token_secret": "token_secret",
+        },
+    )
+    long_text = "x" * 500
+    mail_payload.message = long_text
+
+    with patch("requests_oauthlib.OAuth1Session.post") as mock_post:
+        mock_response = requests.Response()
+        mock_response.status_code = 201
+        mock_response._content = b"{}"
+        mock_post.return_value = mock_response
+
+        XDispatcher(ch).send("ignored", mail_payload)
+        args, kwargs = mock_post.call_args
+        assert len(kwargs["json"]["text"]) == 280
+
+
+def test_x_missing_config(mail_payload: requests.Response) -> None:
+    ch = Channel(dispatcher=fqn(XDispatcher), config={})
+
+    with pytest.raises(DispatcherError):
+        XDispatcher(ch).send("ignored", mail_payload)
+
+
+def test_x_extra_config_info() -> None:
+    ch = Channel(dispatcher=fqn(XDispatcher), config={})
+    info = XDispatcher(ch).get_extra_config_info()
+    assert "280 characters" in info
+    assert "developer.x.com" in info
+    assert "Read and Write" in info


### PR DESCRIPTION
## Summary

- Add X (Twitter) dispatcher with OAuth 1.0a config, 280-char truncation, docs, and tests