### PR TITLE
docs: update documentation for 2.5.0 release

### DIFF
--- a/docs/adm-guide/agents.md
+++ b/docs/adm-guide/agents.md
@@ -14,7 +14,7 @@ Detect changes in local filesystem
 
 ### AgentFTP
 
-Detect changes in remote FTP folder
+Detect changes in remote FTP folder. Supports FTP over TLS (FTPS) with automatic fallback to plain FTP.
 
 
 ### AgentImap

--- a/docs/adm-guide/dispatchers/.pages
+++ b/docs/adm-guide/dispatchers/.pages
@@ -9,4 +9,5 @@ dispatchers:
     - sys.md
     - teams.md
     - twilio.md
+    - user_message.md
     - x.md

--- a/docs/adm-guide/dispatchers/sendgrid.md
+++ b/docs/adm-guide/dispatchers/sendgrid.md
@@ -4,14 +4,16 @@ The SendGrid dispatcher sends notifications via SendGrid's API.
 
 ## Configuration
 
-The following parameter is required to configure the SendGrid dispatcher:
+The following parameters are available to configure the SendGrid dispatcher:
 
-- **API Key**: Your SendGrid API Key.
+- **API Key** (required): Your SendGrid API Key.
+- **From Address** (optional): Override the sender email address.
+- **From Name** (optional): Override the sender display name.
 
 ## How to use
 
 1.  Select `SendGrid` as dispatcher for a Channel
-2.  Fill the form with your SendGrid API Key.
+2.  Fill the form with your SendGrid API Key and optionally a from address/name.
 3.  Save the Channel.
 
 Now you can add this channel to your Application and send notifications.

--- a/docs/adm-guide/dispatchers/user_message.md
+++ b/docs/adm-guide/dispatchers/user_message.md
@@ -1,0 +1,19 @@
+# User Messages Dispatcher
+
+The User Messages dispatcher sends notifications as in-app messages visible in the user's Bitcaster console.
+
+## Configuration
+
+The following parameters are required to configure the User Messages dispatcher:
+
+- **Auto Assign**: Automatically assign users to this channel when they receive a message.
+- **Event**: The event to trigger when notifying users of new messages.
+- **Message TTL**: Number of days read messages are kept before automatic deletion.
+
+## How to use
+
+1.  Select `User Messages` as dispatcher for a Channel
+2.  Configure the associated event, auto-assign behavior, and message retention.
+3.  Save the Channel.
+
+Now you can add this channel to your Application and send notifications. Users will see messages in their Bitcaster console under the messages section.

--- a/docs/adm-guide/sso.md
+++ b/docs/adm-guide/sso.md
@@ -8,34 +8,37 @@ tags:
 Social Login is managed via **django-allauth** and can be configured at <https://SERVER_ADDRESS/admin/social/socialprovider/>
 
 1. Navigate to <https://SERVER_ADDRESS/admin/social/socialprovider/add/>
-2. Select a provider from the list (e.g., `google`, `github`, `microsoft`).
+2. Select a provider from the list — all registered `django-allauth` providers are available dynamically (e.g., `google`, `github`, `microsoft`, `openid_connect`).
 3. Fill in the **Client ID** and **Secret** fields.
 4. If the provider requires an extra key (like Twitter), fill in the **Key** field.
 5. Use the **Extra Configuration** JSON field for any provider-specific parameters (e.g., `server_url` for Keycloak).
 6. Ensure `enabled` is checked before saving.
 
-## Supported Providers
+## Dynamic Provider Support
 
-### Google
-Requires a Google Cloud Project with OAuth 2.0 credentials.
-The redirect URI must be: `http://<your-domain>/social/google/login/callback/`
+Providers are no longer hardcoded — any `django-allauth` provider registered in the system can be used. The provider list in the admin UI is built dynamically from the allauth registry.
 
-### GitHub
-Requires a GitHub OAuth App.
-Redirect URI: `http://<your-domain>/social/github/login/callback/`
+### OpenID Connect (OIDC) Multi-Tenancy
 
-### Microsoft (Azure AD)
-Requires an application registered in the Azure Portal.
-Redirect URI: `http://<your-domain>/social/microsoft/login/callback/`
+Bitcaster supports multiple OpenID Connect tenants (e.g., separate Keycloak realms or different OIDC providers) simultaneously. Each provider configuration is uniquely identified by the combination of **Client ID** and **Provider** type, allowing you to register distinct OIDC realms with their own credentials.
 
-### Keycloak (OpenID Connect)
-Managed via the **Keycloak** provider.
-Set **Client ID** and **Secret**, then add the server URL in **Extra Configuration**:
+To configure an OIDC provider:
+1. Select `openid_connect` as the provider.
+2. Set **Client ID** and **Secret** from your OIDC provider.
+3. Add the server URL in **Extra Configuration** as in following example:
 ```json
 {
   "server_url": "https://<keycloak-url>/auth/realms/<realm>/.well-known/openid-configuration"
 }
 ```
+4. Repeat for additional OIDC tenants with different Client IDs.
+
+### Redirect URIs
+
+The callback URL uses the `SocialProvider` primary key (visible in the admin list):
+`http://<your-domain>/social/<pk>/login/callback/`
+
+The pk is assigned automatically when you create the provider record.
 
 ---
 

--- a/docs/glossary/terms/environment.md
+++ b/docs/glossary/terms/environment.md
@@ -1,5 +1,5 @@
 ---
-description:  "Something happening in an Application that could be notified to users."
+description:  "Deployment environments for routing notifications (staging, QA, production)."
 template: term.html
 terms:
   - glossary:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-copyright: Copyright &copy; 2020-2024 OS4D ltd.
+copyright: Copyright &copy; 2020-2026 OS4D ltd.
 dev_addr: 127.0.0.1:8001
 docs_dir: docs
 edit_uri: 'blob/develop/docs/'


### PR DESCRIPTION
- SSO: replace hardcoded provider list with dynamic provider support, multi-OIDC tenancy docs, and fix callback URL to use pk
- SendGrid: document from_address and from_label optional fields
- UserMessage: add missing dispatcher documentation and nav entry
- Agents: add FTPS support note to AgentFTP
- Glossary: fix Environment term description (was Event copy-paste)
- Copyright: update year to 2026

# Legal Boilerplate

Look, I get it.
Contributing to Bitcaster, I retain all rights, title and interest in and to my contributions, and by keeping
this boilerplate intact I confirm that Bitcaster can use, modify, copy, and redistribute my contributions,
under Bitcaster's choice of terms.
