### PR TITLE
feat(console): add filter by application and event

### DIFF
--- a/src/bitcaster/console/views.py
+++ b/src/bitcaster/console/views.py
@@ -11,7 +11,7 @@ from django.views.generic import DetailView, TemplateView, UpdateView
 from django.views.generic.base import ContextMixin
 
 from bitcaster.forms.unfold import UnfoldAdminSelectWidget, UnfoldForm
-from bitcaster.models import User, UserMessage
+from bitcaster.models import Application, Event, User, UserMessage
 from bitcaster.web.views import UnfoldViewMixin
 
 from .utils import (
@@ -42,12 +42,17 @@ class UserConsoleIndexView(UserConsoleMixin, LoginRequiredMixin, TemplateView):
     paginate_by = 25
 
     def get_queryset(self) -> QuerySet[UserMessage]:
-        qs = self.request.user.bitcaster_messages.order_by("-created")
+        user = cast("User", self.request.user)
+        qs = user.bitcaster_messages.order_by("-created")
         status = self.request.GET.get("status")
         if status == "unread":
             qs = qs.filter(read__isnull=True)
         elif status == "read":
             qs = qs.filter(read__isnull=False)
+        if application := self.request.GET.get("application"):
+            qs = qs.filter(event__application_id=application)
+        if event := self.request.GET.get("event"):
+            qs = qs.filter(event_id=event)
         return qs
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
@@ -63,6 +68,17 @@ class UserConsoleIndexView(UserConsoleMixin, LoginRequiredMixin, TemplateView):
 
         set_user_latest_display_time(self.request.user.pk)  # type: ignore[arg-type]
         set_user_latest_notify_time(self.request.user.pk)  # type: ignore[arg-type]
+
+        current_application = self.request.GET.get("application")
+        current_event = self.request.GET.get("event")
+        applications = Application.objects.filter(events__usermessage__user=self.request.user).distinct()
+        events = Event.objects.none()
+        if current_application:
+            events = Event.objects.filter(
+                application_id=current_application,
+                usermessage__user=self.request.user,
+            ).distinct()
+
         ctx.update(
             user=self.request.user,
             user_messages=MessageFormSet(queryset=page_obj.object_list),  # type: ignore[arg-type]
@@ -71,6 +87,10 @@ class UserConsoleIndexView(UserConsoleMixin, LoginRequiredMixin, TemplateView):
             details_url="console:detail",
             last_notify=last_notify,
             current_status=self.request.GET.get("status", "all"),
+            applications=applications,
+            events=events,
+            current_application=current_application,
+            current_event=current_event,
         )
         return ctx
 

--- a/src/bitcaster/web/templates/bitcaster/console/_messages.html
+++ b/src/bitcaster/web/templates/bitcaster/console/_messages.html
@@ -6,15 +6,47 @@
 {% endblock %}
 <!-- Filter Selector -->
 <div class="pwa-filter-container">
-    <a href="?status=all" class="pwa-filter-item {% if current_status == 'all' %}active{% endif %}">
+    <a href="?status=all{% if current_application %}&application={{ current_application }}{% endif %}{% if current_event %}&event={{ current_event }}{% endif %}"
+       class="pwa-filter-item {% if current_status == 'all' %}active{% endif %}">
         {% trans "All" %}
     </a>
-    <a href="?status=unread" class="pwa-filter-item {% if current_status == 'unread' %}active{% endif %}">
+    <a href="?status=unread{% if current_application %}&application={{ current_application }}{% endif %}{% if current_event %}&event={{ current_event }}{% endif %}"
+       class="pwa-filter-item {% if current_status == 'unread' %}active{% endif %}">
         {% trans "Not Read" %}
     </a>
-    <a href="?status=read" class="pwa-filter-item {% if current_status == 'read' %}active{% endif %}">
+    <a href="?status=read{% if current_application %}&application={{ current_application }}{% endif %}{% if current_event %}&event={{ current_event }}{% endif %}"
+       class="pwa-filter-item {% if current_status == 'read' %}active{% endif %}">
         {% trans "Read" %}
     </a>
+</div>
+<div class="pwa-filter-container">
+    <div class="pwa-filter-item" style="flex: 1;">
+        <select class="w-full bg-transparent border-none focus:ring-0 focus:outline-none cursor-pointer p-1 text-sm"
+                onchange="location.href='?status={{ current_status }}{% if current_event %}&event={{ current_event }}{% endif %}&application=' + encodeURIComponent(this.value)">
+            <option value="">
+                {% trans "All Applications" %}
+            </option>
+            {% for app in applications %}
+                <option value="{{ app.pk }}" {% if current_application|slugify == app.pk|slugify %}selected{% endif %}>
+                    {{ app.name }}
+                </option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="pwa-filter-item" style="flex: 1;">
+        <select class="w-full bg-transparent border-none focus:ring-0 focus:outline-none p-1 text-sm{% if not current_application %} opacity-40 cursor-not-allowed{% else %} cursor-pointer{% endif %}"
+                onchange="location.href='?status={{ current_status }}{% if current_application %}&application={{ current_application }}{% endif %}&event=' + encodeURIComponent(this.value)"
+                {% if not current_application %}disabled{% endif %}>
+            <option value="">
+                {% trans "All Events" %}
+            </option>
+            {% for ev in events %}
+                <option value="{{ ev.pk }}" {% if current_event|slugify == ev.pk|slugify %}selected{% endif %}>
+                    {{ ev.name }}
+                </option>
+            {% endfor %}
+        </select>
+    </div>
 </div>
 <div class="space-y-4" id="user_messages">
     {% for message in user_messages %}
@@ -48,7 +80,8 @@
 </div>
 <div class="pwa-pagination mb-10">
     {% if page_obj.has_previous %}
-        <a href="?page={{ page_obj.previous_page_number }}" class="btn">{% trans "Previous" %}</a>
+        <a href="?page={{ page_obj.previous_page_number }}&status={{ current_status }}{% if current_application %}&application={{ current_application }}{% endif %}{% if current_event %}&event={{ current_event }}{% endif %}"
+           class="btn">{% trans "Previous" %}</a>
     {% else %}
         <span class="btn disabled">{% trans "Previous" %}</span>
     {% endif %}
@@ -56,7 +89,8 @@
         {{ page_obj.number }} / {{ paginator.num_pages }}
     </span>
     {% if page_obj.has_next %}
-        <a href="?page={{ page_obj.next_page_number }}" class="btn">{% trans "Next" %}</a>
+        <a href="?page={{ page_obj.next_page_number }}&status={{ current_status }}{% if current_application %}&application={{ current_application }}{% endif %}{% if current_event %}&event={{ current_event }}{% endif %}"
+           class="btn">{% trans "Next" %}</a>
     {% else %}
         <span class="btn disabled">{% trans "Next" %}</span>
     {% endif %}

--- a/tests/console/test_console_view.py
+++ b/tests/console/test_console_view.py
@@ -94,3 +94,67 @@ def test_pwa_index_filtering(django_app, user: "User", user_messages: "list[User
         assert all(m.instance.read is None for m in messages)
     elif status == "read":
         assert all(m.instance.read is not None for m in messages)
+
+
+@pytest.mark.django_db
+def test_console_index_filter_by_application(django_app, user: "User") -> None:
+    from testutils.factories import EventFactory, UserMessageFactory
+
+    event1 = EventFactory()
+    event2 = EventFactory()
+    msg1 = UserMessageFactory(user=user, event=event1)
+    UserMessageFactory(user=user, event=event2)
+
+    django_app.set_user(user)
+    response = django_app.get(reverse("console:index") + f"?application={event1.application.pk}")
+    assert response.status_code == 200
+    messages = [f.instance for f in response.context["user_messages"]]
+    assert len(messages) == 1
+    assert messages[0].pk == msg1.pk
+
+
+@pytest.mark.django_db
+def test_console_index_filter_by_application_no_messages(django_app, user: "User") -> None:
+    from testutils.factories import ApplicationFactory
+
+    app = ApplicationFactory()
+
+    django_app.set_user(user)
+    response = django_app.get(reverse("console:index") + f"?application={app.pk}")
+    assert response.status_code == 200
+    messages = [f.instance for f in response.context["user_messages"]]
+    assert len(messages) == 0
+
+
+@pytest.mark.django_db
+def test_console_index_filter_by_event(django_app, user: "User") -> None:
+    from testutils.factories import EventFactory, UserMessageFactory
+
+    event1 = EventFactory()
+    event2 = EventFactory(application=event1.application)
+    msg1 = UserMessageFactory(user=user, event=event1)
+    UserMessageFactory(user=user, event=event2)
+
+    django_app.set_user(user)
+    response = django_app.get(reverse("console:index") + f"?event={event1.pk}")
+    assert response.status_code == 200
+    messages = [f.instance for f in response.context["user_messages"]]
+    assert len(messages) == 1
+    assert messages[0].pk == msg1.pk
+
+
+@pytest.mark.django_db
+def test_console_index_applications_context(django_app, user: "User") -> None:
+    from testutils.factories import EventFactory, UserMessageFactory
+
+    event1 = EventFactory()
+    event2 = EventFactory()
+    UserMessageFactory(user=user, event=event1)
+    UserMessageFactory(user=user, event=event2)
+
+    django_app.set_user(user)
+    response = django_app.get(reverse("console:index"))
+    assert response.status_code == 200
+    apps = list(response.context["applications"])
+    assert event1.application in apps
+    assert event2.application in apps


### PR DESCRIPTION
## Problem

The PWA console shows all user messages in a single flat list with only read/unread filtering. As message volume grows, finding messages from a specific application or event requires scrolling through pages.

## Solution

Add two cascading dropdown filters — Application and Event (enabled only after selecting an app). Both are scoped to apps/events that actually have messages for the current user. Status tabs and pagination links now preserve all active filters, and changing any filter resets to page 1.

Closes #196

---

# Legal Boilerplate

Look, I get it.
Contributing to Bitcaster, I retain all rights, title and interest in and to my contributions, and by keeping
this boilerplate intact I confirm that Bitcaster can use, modify, copy, and redistribute my contributions,
under Bitcaster's choice of terms.
