### PR TITLE
fix: allow upgrade() with multiple superusers

### DIFF
--- a/src/bitcaster/management/commands/upgrade.py
+++ b/src/bitcaster/management/commands/upgrade.py
@@ -174,8 +174,6 @@ class Command(BaseCommand):
                     )
 
                 admin = User.objects.get(email=self.admin_email)
-            elif system_org := Organization.objects.filter(name=Bitcaster.ORGANIZATION).first():
-                admin = system_org.owner
             else:
                 admin = User.objects.filter(is_superuser=True).first()
 
@@ -192,11 +190,11 @@ class Command(BaseCommand):
             Group.objects.get_or_create(name="Admins")
             Group.objects.get_or_create(name=DEFAULT_GROUP_NAME)
 
-            if not (system_org := Organization.objects.local().first()):
-                system_org = Organization.objects.create(name="Organization", owner=admin)
+            if not (org := Organization.objects.local().first()):
+                org = Organization.objects.create(name="Organization", owner=admin)
 
             if not Project.objects.local().exists():
-                Project.objects.create(name="Project", owner=admin, organization=system_org)
+                Project.objects.create(name="Project", owner=admin, organization=org)
             init_scheduler()
 
             echo("Upgrade completed", style_func=self.style.SUCCESS)

--- a/src/bitcaster/management/commands/upgrade.py
+++ b/src/bitcaster/management/commands/upgrade.py
@@ -174,8 +174,10 @@ class Command(BaseCommand):
                     )
 
                 admin = User.objects.get(email=self.admin_email)
+            elif system_org := Organization.objects.filter(name=Bitcaster.ORGANIZATION).first():
+                admin = system_org.owner
             else:
-                admin = User.objects.filter(is_superuser=True).get()
+                admin = User.objects.filter(is_superuser=True).first()
 
             if not admin:
                 raise CommandError("Create an admin user")
@@ -190,11 +192,11 @@ class Command(BaseCommand):
             Group.objects.get_or_create(name="Admins")
             Group.objects.get_or_create(name=DEFAULT_GROUP_NAME)
 
-            if not (org := Organization.objects.local().first()):
-                org = Organization.objects.create(name="Organization", owner=admin)
+            if not (system_org := Organization.objects.local().first()):
+                system_org = Organization.objects.create(name="Organization", owner=admin)
 
             if not Project.objects.local().exists():
-                Project.objects.create(name="Project", owner=admin, organization=org)
+                Project.objects.create(name="Project", owner=admin, organization=system_org)
             init_scheduler()
 
             echo("Upgrade completed", style_func=self.style.SUCCESS)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -82,6 +82,20 @@ def test_upgrade(verbosity: int, migrate: int, monkeypatch: pytest.MonkeyPatch, 
     assert "error" not in str(out.getvalue())
 
 
+def test_upgrade_multi_superuser(environment: dict[str, str]) -> None:
+    from testutils.factories import OrganizationFactory, SuperUserFactory
+
+    from bitcaster.constants import bitcaster
+
+    owner = SuperUserFactory()
+    OrganizationFactory(name=bitcaster.ORGANIZATION, slug=bitcaster.ORGANIZATION.lower(), owner=owner)
+    SuperUserFactory()
+    out = StringIO()
+    with mock.patch.dict(os.environ, environment, clear=True):
+        call_command("upgrade", stdout=out, check=False)
+    assert "error" not in str(out.getvalue())
+
+
 def test_upgrade_next(mocked_responses: RequestsMock) -> None:
     from testutils.factories import ProjectFactory, SuperUserFactory
 


### PR DESCRIPTION
Closes #197 .

## Root cause

`upgrade()` called `User.objects.get(is_superuser=True)`, which raises `MultipleObjectsReturned` when more than one superuser exists — crashing the application on restart/redeploy.

## Solution

Changed `.get()` to `.first()` so any superuser works without crashing.

---

# Legal Boilerplate

Look, I get it.
Contributing to Bitcaster, I retain all rights, title and interest in and to my contributions, and by keeping
this boilerplate intact I confirm that Bitcaster can use, modify, copy, and redistribute my contributions,
under Bitcaster's choice of terms.
