### PR TITLE
feat(docker): add docker test infra and ContainerHost improvements

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,4 @@
 FROM python:3.13-slim-bookworm AS base_os
-ARG VERSION
-ARG GIT_SHA
-ARG BUILD_DATE
 
 RUN set -x \
   && apt-get update && apt-get install -y --no-install-recommends debian-archive-keyring \
@@ -66,11 +63,8 @@ RUN mkdir /code /venv
 WORKDIR /code
 COPY . /code
 
-RUN ls -al /code/src/
 RUN uv venv --no-cache $VIRTUAL_ENV \
-    && uv sync --no-dev --frozen --no-editable --no-cache \
-    && git status \
-    && uv build
+    && uv sync --no-dev --frozen --no-editable --no-cache
 
 FROM base_os AS dist
 ARG VERSION
@@ -81,6 +75,7 @@ ADD docker/bin/* /usr/local/bin/
 
 COPY --from=builder /usr/local/bin/uwsgi /usr/local/bin/
 COPY --from=builder /venv /venv
+COPY --from=builder /RELEASE /RELEASE
 RUN mkdir -p /var/storage/media/ /var/storage/static/ \
     && chown -R bitcaster /var/storage/
 
@@ -90,7 +85,7 @@ ENV PATH=/venv/bin:/usr/local/bin/:/usr/bin:/bin:/usr/sbin \
     PYTHONDONTWRITEBYTECODE=1 \
     DJANGO_SETTINGS_MODULE="bitcaster.config.settings" \
     STATIC_URL="/static/" \
-    PYTHONPATH="/venv/lib/python3.13/site-packages"\
+    PYTHONPATH="/venv/lib/python*/site-packages"\
     GIT_SHA=$GIT_SHA \
     PGSSLCERT="/tmp/postgresql.crt" \
     UWSGI_PROCESSES=4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ dev = [
   "ruff>=0.11.13",
   "selenium>=4.18.1",
   "seleniumbase>=4.38.3",
+  "testinfra>=6",
   "tox",
 ]
 docs = [

--- a/src/bitcaster/web/templates/bitcaster/index.html
+++ b/src/bitcaster/web/templates/bitcaster/index.html
@@ -9,10 +9,10 @@
         <div class="flex justify-center">
             {#            <img style="width: 400px" src="{% static "bitcaster/images/logos/name.svg" %}" />#}
             <template x-if="adminTheme === 'dark'">
-                <img class="align-middle h-8" src="{% static "bitcaster/images/logos/name_white.svg" %}" />
+                <img alt="Bitcaster" class="align-middle h-8" src="{% static "bitcaster/images/logos/name_white.svg" %}" />
             </template>
             <template x-if="adminTheme !== 'dark'">
-                <img class="align-middle h-8" src="{% static "bitcaster/images/logos/name.svg" %}" />
+                <img alt="Bitcaster" class="align-middle h-8" src="{% static "bitcaster/images/logos/name.svg" %}" />
             </template>
         </div>
         <div class="flex justify-center gap-2 mt-4 mb-10">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,11 +51,25 @@ def pytest_addoption(parser) -> None:
         help="set sentry environment",
     )
 
+    parser.addoption(
+        "--test-docker",
+        action="store_true",
+        dest="test_docker",
+        default=False,
+        help="run only docker container integration tests",
+    )
+
 
 def pytest_configure(config):
     os.environ.update(DJANGO_SETTINGS_MODULE="bitcaster.config.settings")
     os.environ.setdefault("MEDIA_ROOT", "/tmp/static/")
     os.environ.setdefault("STATIC_ROOT", "/tmp/media/")
+
+    if config.option.test_docker:
+        config.option.cov_fail_under = 0
+        cov = config.pluginmanager.get_plugin("_cov")
+        if cov is not None:
+            cov.fail_under = 0
     os.environ.setdefault("TEST_EMAIL_SENDER", "sender@example.com")
     os.environ.setdefault("TEST_EMAIL_RECIPIENT", "recipient@example.com")
 
@@ -97,6 +111,7 @@ def pytest_configure(config):
         os.environ["SENTRY_ENVIRONMENT"] = config.option.sentry_environment
 
     config.addinivalue_line("markers", "skip_test_if_env(env): this mark skips the tests for the given env")
+    config.addinivalue_line("markers", "docker: docker container integration tests (use --test-docker)")
     from django.conf import settings
 
     settings.ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
@@ -123,6 +138,16 @@ def pytest_configure(config):
         call_command("env", check=True)
     except CommandError:
         pytest.exit("FATAL: Environment variables missing")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.option.test_docker:
+        items[:] = [item for item in items if item.get_closest_marker("docker")]
+    else:
+        skip = pytest.mark.skip(reason="use --test-docker to enable")
+        for item in items:
+            if item.get_closest_marker("docker"):
+                item.add_marker(skip)
 
 
 def run_sql(sql):

--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -1,0 +1,24 @@
+# Docker Integration Tests
+
+This directory contains integration tests for the Bitcaster Docker image.
+Tests validate both the image structure (Python version, installed packages,
+user/group setup) and the running server (uWSGI process, healthcheck, HTTP
+responses).
+
+## Libraries
+
+- **[pytest](https://docs.pytest.org/):** Test framework.
+- **[pytest-docker](https://github.com/avast/pytest-docker):** Manages the
+  Docker Compose lifecycle. Spins up the full stack (app + PostgreSQL + Redis)
+  defined in `stack-samples/develop/compose.yml` for the test session.
+- **[pytest-testinfra](https://testinfra.readthedocs.io/):** Provides the
+  `docker_container` and `started_server` fixtures to inspect Docker
+  containers programmatically (run commands, check users/groups, test
+  network services).
+
+## Running
+
+```bash
+# Run the tests (image is built automatically by compose)
+pytest tests/ --test-docker --no-cov -vv  --capture no
+```

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -1,0 +1,275 @@
+import logging
+import subprocess
+
+import testinfra
+
+import pytest
+from testutils.docker import ContainerHost
+
+logging.getLogger("testinfra").disabled = True
+logging.getLogger("testinfra").propagate = False
+
+NETWORK_NAME = "bitcaster-test-net"
+
+
+SERVER_NAMES = {
+    "pg": "bitcaster-test-pg",
+    "redis": "bitcaster-test-redis",
+    "server": "bitcaster-test-server",
+}
+
+
+def _cleanup() -> None:
+    for name in SERVER_NAMES.values():
+        subprocess.run(["docker", "rm", "-f", name], capture_output=True, check=False)
+    result = subprocess.run(
+        ["docker", "network", "inspect", NETWORK_NAME, "--format", "{{range .Containers}}{{.Name}} {{end}}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        for cname in result.stdout.strip().split():
+            subprocess.run(
+                ["docker", "network", "disconnect", "-f", NETWORK_NAME, cname], capture_output=True, check=False
+            )
+            subprocess.run(["docker", "rm", "-f", cname], capture_output=True, check=False)
+    subprocess.run(["docker", "network", "rm", NETWORK_NAME], capture_output=True, check=False)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup() -> None:
+    _cleanup()
+    yield
+    _cleanup()
+
+
+@pytest.fixture(scope="session")
+def docker_container():
+    image_name = "bitcaster:test"
+    build_args = [
+        "docker",
+        "build",
+        "-t",
+        image_name,
+        "-f",
+        "docker/Dockerfile",
+        "--build-arg",
+        "VERSION=0.0.0",
+        "--build-arg",
+        "GIT_SHA=test",
+        "--build-arg",
+        "BUILD_DATE=2026-01-01",
+        ".",
+    ]
+    subprocess.check_call(build_args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    container_id = (
+        subprocess.check_output(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--entrypoint",
+                "sleep",
+                image_name,
+                "infinity",
+            ],
+            stderr=subprocess.DEVNULL,
+        )
+        .decode()
+        .strip()
+    )
+    yield testinfra.get_host("docker://" + container_id)
+    subprocess.check_call(["docker", "rm", "-f", container_id], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+@pytest.fixture(scope="session")
+def postgres_container():
+    _cleanup()
+
+    network_name = NETWORK_NAME
+    pg_name = SERVER_NAMES["pg"]
+    subprocess.check_call(
+        ["docker", "network", "create", network_name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
+
+    subprocess.check_output(
+        [
+            "docker",
+            "run",
+            "-d",
+            "--network",
+            network_name,
+            "--name",
+            pg_name,
+            "-e",
+            "POSTGRES_USER=bitcaster",
+            "-e",
+            "POSTGRES_PASSWORD=password",
+            "-e",
+            "POSTGRES_DB=bitcaster_test",
+            "postgres:15",
+        ],
+        stderr=subprocess.DEVNULL,
+    )
+
+    _wait_for_postgres(pg_name)
+
+    yield pg_name
+    subprocess.check_call(["docker", "rm", "-f", pg_name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+@pytest.fixture(scope="session")
+def started_server(postgres_container):
+    image_name = "bitcaster:test"
+    network_name = NETWORK_NAME
+    redis_name = SERVER_NAMES["redis"]
+    server_name = SERVER_NAMES["server"]
+    pg_name = postgres_container
+
+    build_args = [
+        "docker",
+        "build",
+        "-t",
+        image_name,
+        "-f",
+        "docker/Dockerfile",
+        "--build-arg",
+        "VERSION=0.0.0",
+        "--build-arg",
+        "GIT_SHA=test",
+        "--build-arg",
+        "BUILD_DATE=2026-01-01",
+        ".",
+    ]
+
+    redis_id = (
+        subprocess.check_output(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--network",
+                network_name,
+                "--name",
+                redis_name,
+                "redis:7-alpine",
+            ],
+            stderr=subprocess.DEVNULL,
+        )
+        .decode()
+        .strip()
+    )
+
+    subprocess.check_call(build_args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    container_id = (
+        subprocess.check_output(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--network",
+                network_name,
+                "--name",
+                server_name,
+                "-p",
+                "8003:8000",
+                "-e",
+                f"DATABASE_URL=postgres://bitcaster:password@{pg_name}:5432/bitcaster_test",
+                "-e",
+                f"CACHE_URL=redis://{redis_name}:6379/1",
+                "-e",
+                "SECRET_KEY=test-key-not-for-production",
+                "-e",
+                f"DRAMATIQ_BROKER=redis://{redis_name}:6379/0",
+                "-e",
+                "MEDIA_ROOT=/tmp/media",
+                "-e",
+                "STATIC_ROOT=/tmp/static",
+                "-e",
+                "BITCASTER_LOGGING_LEVEL=DEBUG",
+                "-e",
+                "CSRF_COOKIE_SECURE=False",
+                "-e",
+                "SESSION_COOKIE_SECURE=False",
+                "-e",
+                "SOCIAL_AUTH_REDIRECT_IS_HTTPS=False",
+                "-e",
+                "SECURE_SSL_REDIRECT=False",
+                "-e",
+                "SECURE_HSTS_PRELOAD=0",
+                "-e",
+                "ALLOWED_HOSTS=localhost,127.0.0.1",
+                "-e",
+                "ADMIN_EMAIL=admin@example.com",
+                "-e",
+                "ADMIN_PASSWORD=password",
+                "-e",
+                "GIT_SHA=test",
+                image_name,
+                "run",
+            ],
+            stderr=subprocess.DEVNULL,
+        )
+        .decode()
+        .strip()
+    )
+
+    _wait_for_server(container_id)
+    yield ContainerHost(
+        host=testinfra.get_host("docker://" + container_id),
+        container_id=container_id,
+    )
+    subprocess.check_call(["docker", "rm", "-f", server_name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    subprocess.check_call(["docker", "rm", "-f", redis_id], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _wait_for_postgres(pg_name, timeout=30):
+    import time
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        result = subprocess.run(
+            ["docker", "exec", pg_name, "pg_isready", "-U", "bitcaster", "-d", "bitcaster_test"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if result.returncode == 0:
+            return
+        time.sleep(1)
+    raise RuntimeError("PostgreSQL did not become ready within timeout")
+
+
+def _wait_for_server(container_id, timeout=120):
+    import time
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        result = subprocess.run(
+            [
+                "docker",
+                "exec",
+                container_id,
+                "sh",
+                "-c",
+                'python3 -c "import http.client; '
+                "c = http.client.HTTPConnection('localhost', 8000, timeout=5); "
+                "c.request('GET', '/healthcheck/'); "
+                "r = c.getresponse(); "
+                'print(r.status); r.read()"',
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip().isdigit():
+            return
+        time.sleep(5)
+    logs = subprocess.run(
+        ["docker", "logs", "--tail", "30", container_id], capture_output=True, text=True, timeout=5, check=False
+    )
+    raise RuntimeError(f"Server did not start within timeout\nSTDOUT: {logs.stdout}\nSTDERR: {logs.stderr}")

--- a/tests/docker/test_docker_image.py
+++ b/tests/docker/test_docker_image.py
@@ -1,0 +1,50 @@
+import pytest
+
+pytestmark = pytest.mark.docker
+
+
+def test_python_version(docker_container) -> None:
+    result = docker_container.run("python3 --version")
+    assert result.rc == 0
+    assert "3.13" in result.stdout
+
+
+def test_uwsgi_installed(docker_container) -> None:
+    assert docker_container.run("which uwsgi").rc == 0
+
+
+def test_bitcaster_user(docker_container) -> None:
+    user = docker_container.user("bitcaster")
+    assert user.exists
+    assert user.uid == 1000
+
+
+def test_os4d_group(docker_container) -> None:
+    group = docker_container.group("os4d")
+    assert group.exists
+    assert group.gid == 1024
+
+
+def test_pythonpath(docker_container) -> None:
+    result = docker_container.run("echo $PYTHONPATH")
+    assert "/venv/lib/python3.13" in result.stdout
+
+
+def test_bitcaster_cli(docker_container) -> None:
+    result = docker_container.run("bc --version")
+    assert result.rc == 0
+
+
+def test_bitcaster_code_folder(docker_container) -> None:
+    result = docker_container.run("ls /code")
+    assert result.rc == 2
+    result = docker_container.run("ls /")
+    assert "code" not in result.stdout
+
+
+def test_bitcaster_release(docker_container) -> None:
+    result = docker_container.run("cat /RELEASE")
+    assert result.rc == 0
+
+    result = docker_container.run("release-info.sh")
+    assert result.rc == 0

--- a/tests/docker/test_docker_server.py
+++ b/tests/docker/test_docker_server.py
@@ -1,0 +1,41 @@
+import requests
+
+import pytest
+from testutils.docker import ContainerHost
+
+pytestmark = pytest.mark.docker
+
+CLIENT = (
+    'python3 -c "'
+    "import http.client; "
+    "c = http.client.HTTPConnection('localhost', 8000); "
+    "c.request('GET', '{url}'); "
+    "r = c.getresponse(); "
+    "print(r.status); print(r.read().decode())"
+    '"'
+)
+
+
+def test_healthcheck_returns_200(started_server) -> None:
+    result = started_server.run(CLIENT.format(url="/healthcheck/"))
+    assert result.rc == 0
+    lines = result.stdout.strip().splitlines()
+
+    assert lines[0] == "200"
+    assert "Ok" in lines[1]
+
+
+def test_url_admin(started_server) -> None:
+    result = started_server.run(CLIENT.format(url="/admin/"))
+    assert result.rc == 0
+    lines = result.stdout.strip().splitlines()
+    assert lines[0] in ("301", "302", "200")
+
+
+def test_homepage_returns_response(started_server: ContainerHost) -> None:
+    started_server.lastlog()
+    res = requests.get("http://localhost:8003")
+    assert "Login" in res.text
+    assert res.status_code == 200
+    requests.get("http://localhost:8003/admin/")
+    assert "GET /admin/" in started_server.lastlog()

--- a/tests/extras/testutils/docker.py
+++ b/tests/extras/testutils/docker.py
@@ -1,0 +1,61 @@
+import subprocess
+from dataclasses import dataclass
+
+from testinfra.host import Host
+
+
+@dataclass
+class ContainerLogs:
+    stdout: list[str]
+    stderr: list[str]
+    offset: int
+
+    def __repr__(self) -> str:
+        return "\n".join(self.stdout) + "\n".join(self.stderr)
+
+    def __contains__(self, item):
+        return item in str(self.stdout) or item in str(self.stderr)
+
+
+class ContainerHost:
+    def __init__(self, host: Host, container_id: str) -> None:
+        self.host = host
+        self.container_id = container_id
+        self.bookmarks: dict[str, ContainerLogs] = {}
+        self.offset: int = 0
+        self._stderr_offset: int = 0
+
+    def run(self, *args, **kwargs):
+        return self.host.run(*args, **kwargs)
+
+    def logs(self) -> ContainerLogs:
+        ret = subprocess.run(
+            ["docker", "logs", self.container_id],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        stdout_lines = ret.stdout.split("\n")
+        stderr_lines = ret.stderr.split("\n")
+
+        return ContainerLogs(stdout_lines, stderr_lines, 0)
+
+    def lastlog(self) -> ContainerLogs:
+        ret = subprocess.run(
+            ["docker", "logs", self.container_id],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        stdout_lines = ret.stdout.split("\n")
+        stderr_lines = ret.stderr.split("\n")
+
+        new_stdout = stdout_lines[self.offset :]
+        new_stderr = stderr_lines[self._stderr_offset :]
+
+        self.offset = len(stdout_lines)
+        self._stderr_offset = len(stderr_lines)
+
+        return ContainerLogs(new_stdout, new_stderr, self.offset)

--- a/uv.lock
+++ b/uv.lock
@@ -338,6 +338,7 @@ dev = [
     { name = "ruff" },
     { name = "selenium" },
     { name = "seleniumbase" },
+    { name = "testinfra" },
     { name = "tox" },
 ]
 docs = [
@@ -493,6 +494,7 @@ dev = [
     { name = "ruff", specifier = ">=0.11.13" },
     { name = "selenium", specifier = ">=4.18.1" },
     { name = "seleniumbase", specifier = ">=4.38.3" },
+    { name = "testinfra", specifier = ">=6.0.0" },
     { name = "tox" },
 ]
 docs = [
@@ -3732,6 +3734,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-testinfra"
+version = "10.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/15/b650133bb3eb3509704c7605348bec4205b6a399f7a79874ced6c30a3e15/pytest_testinfra-10.2.2.tar.gz", hash = "sha256:537fd5eb88da618c1f461248aa20594cf8d44512e8519b239837e83875e1e9cd", size = 76153, upload-time = "2025-03-30T09:06:02.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/75/8b002ad110ae4a71bce9bb47020ee77176e27defe99ce6d7b62e52debeb9/pytest_testinfra-10.2.2-py3-none-any.whl", hash = "sha256:b785602b0aa868c858e4ef121a8cc0d13a81c04b74ec0364d70969540f8e7c31", size = 76912, upload-time = "2025-03-30T09:06:00.358Z" },
+]
+
+[[package]]
 name = "pytest-testmon"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4357,6 +4371,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
+]
+
+[[package]]
+name = "testinfra"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest-testinfra" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/aa/35319fcf8935036bb2f8049ffb515d4490b8bfc27cf2d9551d3b4686702e/testinfra-6.0.0.tar.gz", hash = "sha256:4225d36e4bb02eb1618429325280c4b62a18cea8a90c91564ee0cc1d31ca331a", size = 1705, upload-time = "2020-11-12T21:39:44.264Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/6b/021295ce3a3c9cdf8ebd643647c2eeb8329b960b07b4f983a488af291354/testinfra-6.0.0-py3-none-any.whl", hash = "sha256:1a75b5025dbe82ffedec50afeaf9a7f96a8cd1e294f0d40de3a089a369ceae0e", size = 2135, upload-time = "2020-11-12T21:39:43.232Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add ContainerHost test utility with incremental logs() support
- Reduce console noise in docker tests by suppressing subprocess output
- Add test infrastructure for docker image and server tests
- Clean up Dockerfile: remove debug commands (ls, git status)
- Remove unnecessary uv build (output not used by dist stage)
- Use dynamic PYTHONPATH glob instead of hardcoded Python 3.13
- Remove unused ARGs from base_os stage
- Copy /RELEASE from builder to dist stage
- Add tests for RELEASE file and code folder absence
- Fix offset tracking in ContainerLogs with separate stdout/stderr offsets# Legal Boilerplate

Look, I get it.
Contributing to Bitcaster, I retain all rights, title and interest in and to my contributions, and by keeping
this boilerplate intact I confirm that Bitcaster can use, modify, copy, and redistribute my contributions,
under Bitcaster's choice of terms.
