### PR TITLE
fix: hide Members menu item from users without view_member permission

### DIFF
--- a/src/bitcaster/config/fragments/unfold.py
+++ b/src/bitcaster/config/fragments/unfold.py
@@ -152,6 +152,7 @@ UNFOLD = {
                         "title": _("Members"),
                         "icon": "person",
                         "link": reverse_lazy("admin:bitcaster_member_changelist"),
+                        "permission": lambda request: request.user.has_perm("bitcaster.view_member"),
                     },
                     {
                         "title": _("Stream"),

--- a/tests/admin/test_admin_unfold.py
+++ b/tests/admin/test_admin_unfold.py
@@ -1,0 +1,33 @@
+from typing import TYPE_CHECKING
+
+import pytest
+from testutils.factories.user import UserFactory
+from testutils.perms import user_grant_permissions
+
+from django.urls import reverse
+
+if TYPE_CHECKING:
+    from django_webtest import DjangoTestApp
+    from django_webtest.pytest_plugin import MixinWithInstanceVariables
+
+pytestmark = [pytest.mark.admin, pytest.mark.django_db]
+
+
+@pytest.fixture
+def app(django_app_factory: "MixinWithInstanceVariables") -> "DjangoTestApp":
+    django_app = django_app_factory(csrf_checks=False)
+    admin_user = UserFactory(username="staff")
+    django_app.set_user(admin_user)
+    django_app._user = admin_user
+    return django_app
+
+
+def test_members_menu_visible_with_permission(app: "DjangoTestApp") -> None:
+    with user_grant_permissions(app._user, ["bitcaster.view_member"]):
+        res = app.get(reverse("admin:index"))
+    assert "Members" in res
+
+
+def test_members_menu_hidden_without_permission(app: "DjangoTestApp") -> None:
+    res = app.get(reverse("admin:index"))
+    assert "Members" not in res


### PR DESCRIPTION
## Summary

Fixes #206 — the "Members" sidebar menu item was visible to all authenticated users but returned 403 for those without `bitcaster.view_member` permission.

## Changes

- Added `permission` lambda to the Members navigation item in `unfold.py` — checks `request.user.has_perm("bitcaster.view_member")`
- Added tests verifying:
  - Menu is visible when user has `bitcaster.view_member` permission
  - Menu is hidden when user lacks the permission