### PR TITLE
fix: guard ApiKeyForm against null project and environments

### DIFF
--- a/src/bitcaster/admin/api_key.py
+++ b/src/bitcaster/admin/api_key.py
@@ -39,7 +39,7 @@ class ApiKeyForm(Scoped3FormMixin[ApiKey], forms.ModelForm[ApiKey]):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        if self.instance and self.instance.pk:
+        if self.instance and self.instance.pk and self.instance.project and self.instance.project.environments:
             choices = [(k, k) for k in self.instance.project.environments]
             self.fields["environments"] = forms.MultipleChoiceField(
                 choices=choices,

--- a/tests/admin/test_admin_apikey.py
+++ b/tests/admin/test_admin_apikey.py
@@ -115,6 +115,26 @@ def test_add_check_environments(app: "DjangoTestApp", api_key: "ApiKey") -> None
     assert res.status_code == 302, res.context["adminform"].form.errors
 
 
+def test_edit_apikey_without_project(app: DjangoTestApp, db: Any) -> None:
+    from testutils.factories import ApiKeyFactory
+
+    api_key: "ApiKey" = ApiKeyFactory(project=None)
+    opts: Options[ApiKey] = api_key._meta
+    url = reverse(admin_urlname(opts, SafeString("change")), args=[api_key.pk])
+    res = app.get(url)
+    assert res.status_code == 200
+
+
+def test_edit_apikey_with_project_no_environments(app: DjangoTestApp, db: Any) -> None:
+    from testutils.factories import ApiKeyFactory, ProjectFactory
+
+    api_key: "ApiKey" = ApiKeyFactory(project=ProjectFactory(environments=None))
+    opts: Options[ApiKey] = api_key._meta
+    url = reverse(admin_urlname(opts, SafeString("change")), args=[api_key.pk])
+    res = app.get(url)
+    assert res.status_code == 200
+
+
 @pytest.mark.parametrize("flt", ["development", ""])
 def test_add_channel_filter_by_type(app: DjangoTestApp, api_key: "ApiKey", flt: str) -> None:
     url = reverse("admin:bitcaster_apikey_changelist")


### PR DESCRIPTION
## Description

Add null-safety checks to `ApiKeyForm.__init__` to prevent `AttributeError` when editing an `ApiKey` that has no associated project, or when the project has null environments.

## Changes

- `src/bitcaster/admin/api_key.py`: Guard `self.instance.project` and `self.instance.project.environments` before accessing them
- `tests/admin/test_admin_apikey.py`: Add regression tests for both null project and null environments scenarios

## Testing

- `test_edit_apikey_without_project` - ApiKey with `project=None`
- `test_edit_apikey_with_project_no_environments` - ApiKey with `project.environments=None`
- All 11 tests in the file pass