### PR TITLE
feat(admin): manage Distribution List membership from Member page

### DIFF
--- a/docs/adm-guide/dl.md
+++ b/docs/adm-guide/dl.md
@@ -87,3 +87,22 @@ click on `Add Distribution List`{ .bc-tool-button .action }
 
 Enter a name and optionally pin it to an Application. After saving, you can add
 recipients via the `Recipients` button.
+
+## Managing Recipients from the Member Page
+
+Recipients can also be added from a Member's admin page. Open any
+[Member](user_management.md) in the admin and switch to the
+**Distribution Lists** tab. The tab shows two columns per row:
+
+- **Distribution List**: the list the member belongs to.
+- **Assignment**: the member's assignment (`address - channel`) used to reach
+  them in that list.
+
+Existing memberships are shown as pre-selected, read-only rows — the tab does
+**not** create, edit, or delete Distribution Lists.
+
+To add the member to another list, use the empty row at the bottom: pick an
+existing Distribution List from the dropdown (lists the member is already in
+are hidden) and choose one of the member's Assignments. On save, the member
+receives the notification on that channel for the chosen list. Adding a member
+who is already in the list is a no-op.

--- a/src/bitcaster/admin/member.py
+++ b/src/bitcaster/admin/member.py
@@ -55,10 +55,11 @@ class ReadOnlyInline:
 
 class AddressInline(TabularInline):  # NonrelatedStackedInline is available as well
     model = Address
-    fields = ["name", "type"]  # Ignore property to display all fields
+    fields = ["name", "value", "type"]  # Ignore property to display all fields
     extra = 0
     tab = True
-    verbose_name = _("Addresses")
+    verbose_name = _("Address")
+    verbose_name_plural = _("Addresses")
     collapsible = True
 
     def get_form_queryset(self, obj: Member) -> QuerySet[Address]:
@@ -103,18 +104,78 @@ class AssignmentInline(NonrelatedTabularInline):  # NonrelatedStackedInline is a
         return cast("bool", super().has_add_permission(request, obj) and obj and obj.pk)
 
 
+class ListsForm(forms.ModelForm):
+    dl = forms.ModelChoiceField(
+        label=_("Distribution List"),
+        queryset=DistributionList.objects.all(),
+        required=True,
+        widget=uwidgets.UnfoldAdminSelectWidget,
+    )
+    assignment = forms.ModelChoiceField(
+        label=_("Assignment"),
+        queryset=Assignment.objects.none(),
+        required=True,
+        widget=uwidgets.UnfoldAdminSelectWidget,
+    )
+
+    class Meta:
+        model = DistributionList
+        fields = ["dl", "assignment"]
+
+    def __init__(
+        self,
+        *args: Any,
+        user: Member | None = None,
+        dl_initial: DistributionList | None = None,
+        assignment_initial: Assignment | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.user = user
+        user_id = user.pk if user else None
+        self.fields["assignment"].queryset = Assignment.objects.filter(address__user_id=user_id)
+        if dl_initial is not None:
+            self.fields["dl"].initial = dl_initial
+            self.fields["dl"].disabled = True
+            if assignment_initial is not None:
+                self.fields["assignment"].initial = assignment_initial
+                self.fields["assignment"].disabled = True
+        else:
+            self.fields["dl"].queryset = DistributionList.objects.exclude(
+                recipients__address__user_id=user_id
+            ).distinct()
+
+
 class ListsFormSet(NonrelatedInlineModelFormSet):
-    def get_form_kwargs(self, index: int) -> dict[str, Any]:
+    def get_form_kwargs(self, index: int | None) -> dict[str, Any]:
         ret = cast("dict[str, Any]", super().get_form_kwargs(index))
         ret["user"] = self.instance
+        if index is not None and index < self.initial_form_count():
+            dl = self.queryset.all()[index]
+            ret["dl_initial"] = dl
+            ret["assignment_initial"] = dl.recipients.filter(
+                address__user_id=self.instance.pk if self.instance else None
+            ).first()
         return ret
+
+    def save_new(self, form: forms.ModelForm, commit: bool = True) -> DistributionList:
+        dl = form.cleaned_data["dl"]
+        asm = form.cleaned_data["assignment"]
+        if dl is not None and asm is not None:
+            dl.recipients.add(asm)
+        return cast("DistributionList", dl)
 
 
 class ListsInline(NonrelatedTabularInline):  # NonrelatedStackedInline is available as well
     model = DistributionList
     tab = True
-    fields = ["name", "project"]  # Ignore property to display all fields
-    extra = 0
+    fields = ["dl", "assignment"]
+    extra = 1
+    form = ListsForm
+    formset = ListsFormSet
+
+    def get_readonly_fields(self, request: HttpRequest, obj: Member | None = None) -> list[str]:
+        return []
 
     def get_form_queryset(self, obj: Member) -> QuerySet[DistributionList]:
         return obj.get_distribution_lists()

--- a/src/bitcaster/models/user.py
+++ b/src/bitcaster/models/user.py
@@ -110,7 +110,7 @@ class User(LockMixin, BitcasterBaseModel, AbstractUser):
         """Retrieve all distribution lists this user is a recipient of via any assignment."""
         from bitcaster.models import DistributionList
 
-        return DistributionList.objects.filter(recipients__address__user=self)
+        return DistributionList.objects.filter(recipients__address__user=self).distinct()
 
     def format_date(self, d: datetime.datetime) -> str:
         return d.strftime(self.date_format)

--- a/tests/admin/test_admin_member.py
+++ b/tests/admin/test_admin_member.py
@@ -258,3 +258,33 @@ def test_member_distribution_lists_add_no_address(app: "DjangoTestApp", context:
     assert res.status_code == 200
     assert "This field is required" in res.text
     assert not dl.recipients.exists()
+
+
+def test_member_distribution_lists_form_without_assignment(app: "DjangoTestApp", context: "Context"):
+    from bitcaster.admin.member import ListsForm
+
+    member = context["members"][0]
+    dl = context["distributionlist"]
+
+    form = ListsForm(user=member, dl_initial=dl, assignment_initial=None)
+    assert form.fields["dl"].disabled is True
+    assert form.fields["dl"].initial == dl
+    assert form.fields["assignment"].disabled is False
+    assert form.fields["assignment"].initial is None
+
+
+def test_member_distribution_lists_formset_save_new_empty():
+    from types import SimpleNamespace
+
+    from unfold.contrib.inlines.forms import nonrelated_inline_formset_factory
+
+    from bitcaster.admin.member import ListsForm, ListsFormSet
+
+    formset = nonrelated_inline_formset_factory(
+        model=DistributionList,
+        queryset=DistributionList.objects.none(),
+        form=ListsForm,
+        formset=ListsFormSet,
+    )
+    form = SimpleNamespace(cleaned_data={"dl": None, "assignment": None})
+    assert formset().save_new(form) is None

--- a/tests/admin/test_admin_member.py
+++ b/tests/admin/test_admin_member.py
@@ -170,3 +170,91 @@ def test_assignment_inline_list(app: "DjangoTestApp", context: "Context"):
     url = reverse("admin:bitcaster_member_change", args=[member.pk])
     res = app.get(url)
     assert res.status_code == 200
+
+
+def test_member_distribution_lists_assignment_shown(app: "DjangoTestApp", context: "Context"):
+    member = context["members"][0]
+    dl = context["distributionlist"]
+    asm = dl.recipients.first()
+
+    url = reverse("admin:bitcaster_member_change", args=[member.pk])
+    res = app.get(url)
+    assert res.status_code == 200
+    rows = res.pyquery("#bitcaster-distributionlist-group tbody.form-group:not(.template)")
+    assert len(rows) == 1
+    assert res.pyquery("#id_bitcaster-distributionlist-0-dl option[selected]").val() == str(dl.pk)
+    assert res.pyquery("#id_bitcaster-distributionlist-0-assignment option[selected]").val() == str(asm.pk)
+
+
+def test_member_distribution_lists_multiple_assignments_single_row(app: "DjangoTestApp", context: "Context"):
+    from testutils.factories import AddressFactory, AssignmentFactory
+
+    member = context["members"][0]
+    dl = context["distributionlist"]
+    channel = dl.recipients.first().channel
+    dl.recipients.add(AssignmentFactory(address=AddressFactory(user=member), channel=channel))
+
+    url = reverse("admin:bitcaster_member_change", args=[member.pk])
+    res = app.get(url)
+    assert res.status_code == 200
+    rows = res.pyquery("#bitcaster-distributionlist-group tbody.form-group:not(.template)")
+    assert len(rows) == 1
+    assert dl.name in res.text
+    assert member.email in res.text
+
+
+def test_member_distribution_lists_add(app: "DjangoTestApp", context: "Context"):
+    from testutils.factories import DistributionListFactory
+
+    member = context["members"][0]
+    dl = DistributionListFactory.create(project=context["distributionlist"].project)
+    asm = context["distributionlist"].recipients.first()
+
+    url = reverse("admin:bitcaster_member_change", args=[member.pk])
+    res = app.get(url)
+    form = res.forms["member_form"]
+    prefix = "bitcaster-distributionlist"
+    form[f"{prefix}-1-dl"] = dl.pk
+    form[f"{prefix}-1-assignment"] = asm.pk
+
+    res = form.submit().follow()
+    assert res.status_code == 200
+    assert dl.recipients.filter(pk=asm.pk).exists()
+
+
+def test_member_distribution_lists_add_any_assignment(app: "DjangoTestApp", context: "Context"):
+    from testutils.factories import AddressFactory, AssignmentFactory, DistributionListFactory
+
+    member = context["members"][0]
+    dl = DistributionListFactory.create(project=context["distributionlist"].project)
+    first = context["distributionlist"].recipients.first()
+    second = AssignmentFactory(address=AddressFactory(user=member), channel=first.channel)
+
+    url = reverse("admin:bitcaster_member_change", args=[member.pk])
+    res = app.get(url)
+    form = res.forms["member_form"]
+    prefix = "bitcaster-distributionlist"
+    form[f"{prefix}-1-dl"] = dl.pk
+    form[f"{prefix}-1-assignment"] = second.pk
+
+    res = form.submit().follow()
+    assert res.status_code == 200
+    assert list(dl.recipients.values_list("pk", flat=True)) == [second.pk]
+
+
+def test_member_distribution_lists_add_no_address(app: "DjangoTestApp", context: "Context"):
+    from testutils.factories import DistributionListFactory
+
+    member = context["members"][1]
+    dl = DistributionListFactory.create(project=context["distributionlist"].project)
+
+    url = reverse("admin:bitcaster_member_change", args=[member.pk])
+    res = app.get(url)
+    form = res.forms["member_form"]
+    prefix = "bitcaster-distributionlist"
+    form[f"{prefix}-0-dl"] = dl.pk
+
+    res = form.submit()
+    assert res.status_code == 200
+    assert "This field is required" in res.text
+    assert not dl.recipients.exists()

--- a/tests/admin/test_admin_member_extra.py
+++ b/tests/admin/test_admin_member_extra.py
@@ -172,6 +172,7 @@ def test_member_admin_formsets(admin_user):
     m = MagicMock(spec=ListsFormSet)
     m.instance = member
     m.form_kwargs = {}
+    m.initial_form_count.return_value = 0
     ret = ListsFormSet.get_form_kwargs(m, 0)
     assert ret["user"] == member
 


### PR DESCRIPTION
## Summary

Enhance the Member admin page so Distribution List membership can be managed directly from the member.

### Changes

- **Member admin "Distribution Lists" tab** (`src/bitcaster/admin/member.py`): now shows two columns — **Distribution List** and **Assignment** — per row.
  - Existing memberships render as pre-selected, read-only rows (no create/edit/delete of Distribution Lists from here).
  - An empty row at the bottom lets the admin add the member to any existing Distribution List by picking the list (lists the member already belongs to are hidden) and one of the member's Assignments.
  - On save, the chosen Assignment is added to the list's recipients; already being a member is a no-op.
- **`User.get_distribution_lists()`** (`src/bitcaster/models/user.py`): added `.distinct()` to avoid duplicate lists when a member has multiple addresses in the same list.
- **Tests** (`tests/admin/test_admin_member.py`, `test_admin_member_extra.py`): display, multi-assignment single row, add-to-list, add-any-assignment, missing-assignment coverage; fixed the `test_member_admin_formsets` mock.
- **Docs** (`docs/adm-guide/dl.md`): new "Managing Recipients from the Member Page" section.

## Verification

- `tox -e lint` OK, `tox -e mypy` OK
- `tox -e tests`: 1431 passed (1 pre-existing flaky Selenium test, passes on rerun)
- pre-commit hooks all pass

## Notes

- The address used is surfaced through the Assignment select (`address - channel` label).