### PR TITLE
feat(help): admin documentation links

### DIFF
--- a/docs/adm-guide/.pages
+++ b/docs/adm-guide/.pages
@@ -11,6 +11,16 @@ nav:
   - Notification Policies: notification_policies.md
   - Filtering Guide: filtering.md
   - Create Message: message.md
+  - Manage Addresses: address.md
+  - Manage Attachments: attachment.md
+  - Manage Media Files: media.md
+  - Manage Subscriptions: subscription.md
+  - Manage Members: member.md
+  - Work with Occurrences: occurrence.md
+  - Schedule Tasks: tasks.md
+  - Stream: stream.md
+  - Process Log: process_log.md
+  - System Log: system_log.md
   - Command line interface: cli.md
   - Trigger Event: trigger.md
   - Configure Monitors: monitor.md

--- a/docs/adm-guide/abstract_channel_create.md
+++ b/docs/adm-guide/abstract_channel_create.md
@@ -1,5 +1,12 @@
 # Create Abstract Channel
 
+A <glossary:Channel> is the delivery medium of Bitcaster: email, SMS, push,
+chat and so on. An **Abstract Channel** is a reusable template of a channel —
+the provider and its configuration (e.g. the SMTP server, the Slack token) —
+defined once at the organization level and later enabled for as many projects
+as needed. This way the provider settings live in a single place and projects
+just pick the channel they want to use.
+
 !!! note
 
     This is an optional step you can can create standard project channels later.

--- a/docs/adm-guide/address.md
+++ b/docs/adm-guide/address.md
@@ -1,0 +1,31 @@
+---
+tags:
+   - Address
+
+---
+# Manage Addresses
+
+An <glossary:Address> is a delivery endpoint of a user: an email, a phone
+number or any value that a <glossary:Channel> can reach.
+
+## Address list
+
+The address list at <https://SERVER_ADDRESS/admin/bitcaster/address/> shows the
+user each address belongs to, its name, value and type. Use the search box to
+find an address by name or value and filter by user or type.
+
+## Add or edit an address
+
+1. Select the **user** the address belongs to
+1. Provide a **name** (e.g. `work email`) and the **value** (e.g.
+   `john@example.com`)
+1. Choose the **type** of address (email, phone, ...)
+
+## Validate and assign to a channel
+
+An address must be validated before it can be used: select the address and use
+the **Assign to channel** action to pick the <glossary:Channel> and the
+distribution or notification it is validated for.
+
+Validated addresses are used by <glossary:Assignment>s as the destination of
+the message.

--- a/docs/adm-guide/app.md
+++ b/docs/adm-guide/app.md
@@ -1,5 +1,11 @@
 # Add Application
 
+An **Application** is the container of a single product or service in
+Bitcaster: every <glossary:Event>, <glossary:Notification>, channel binding,
+attachment and API key belongs to an Application. Grouping by application lets
+you scope routing, monitoring and keys to one product instead of sharing them
+across everything.
+
 Now that your Organization and Project have been configured, you can start adding all the Applications
 that you want to be served by Bitcaster.
 

--- a/docs/adm-guide/attachment.md
+++ b/docs/adm-guide/attachment.md
@@ -1,0 +1,31 @@
+---
+tags:
+   - Attachment
+
+---
+# Manage Attachments
+
+Attachments are files that can be sent along with a notification. Each
+attachment is linked to an <glossary:Application> and carries a `correlation_id`
+that ties it to an <glossary:Occurrence>.
+
+## Attachment list
+
+The list at <https://SERVER_ADDRESS/admin/bitcaster/attachment/> shows the
+application, the file name and the correlation id of every attachment.
+
+## Upload an attachment
+
+1. Open the [Application](app.md) the attachment belongs to
+1. Upload the file through the application page or the API
+
+The API upload endpoint
+(`o/<org>/p/<prj>/a/<app>/attachment/`) accepts the file together with the
+`correlation_id` of the occurrence it belongs to.
+
+## Download
+
+Recipients receive a signed, expiring download link
+(`/attachment/download/<key>/`) in the message. The key is generated with the
+`SECRET_KEY_SALT` configured in the [Configuration](configuration/) and expires
+after the configured timeout.

--- a/docs/adm-guide/channel_enable.md
+++ b/docs/adm-guide/channel_enable.md
@@ -1,5 +1,11 @@
 # Enable Project Channel
 
+A **Project Channel** binds an abstract channel to a concrete sender for one
+project: the email address the messages are sent from, the Slack workspace,
+the phone number for SMS. It is what makes the project actually able to
+deliver: notifications only reach recipients on channels that are enabled for
+the project.
+
 
 From the [Project page](https://SERVER_ADDRESS/admin/bitcaster/project/current/){:target=_bc}  click on
 `Add Channel`{ .bc-tool-button .action }

--- a/docs/adm-guide/events.md
+++ b/docs/adm-guide/events.md
@@ -1,5 +1,12 @@
 # Register Application Events
 
+An **Event** is the entry point of Bitcaster: anything that happens in your
+systems — a payment completed, a user registered, an alert raised — can become
+an Event. When an Event is triggered, Bitcaster matches it against its
+active <glossary:Notification>s and delivers the messages to the recipients.
+Declaring the Events of your application is what makes those happenings
+reachable by the API.
+
 To allow Bitcaster to process [events][event], those need to be listed and configured.
 
 ## Create Event
@@ -13,3 +20,26 @@ you want make available for this
 Setup which channels can be used to notify this event
 
 ![Image](_screenshots/events/cfg.png)
+
+## Event Simulations
+
+Event Simulations let you dry-run an event before it goes live: Bitcaster
+collects the recipients and renders the messages **without sending anything**.
+
+1. Open the event and click **Run simulation**
+1. Provide the **context** (the payload that would be sent by the caller) and
+   optionally the routing **options**
+1. Choose the **mode**:
+   - **fast** — collect recipients only, no rendering
+   - **partial** — collect recipients and render up to the configured limit
+   - **full** — collect recipients and render for all of them
+1. Save
+
+The simulation status moves from `NEW` to `PROCESSED` when it completes. From
+the **Delivery Simulations** page you can inspect every simulated delivery:
+the recipient, the notification, the message template used and the rendered
+content (`subject`/`message`/`html_message`). Deliveries whose channel has no
+matching <glossary:Message> are flagged as **missing template**.
+
+Simulations are kept for the configured retention
+(`EVENT_SIMULATION_RETENTION`) and purged automatically.

--- a/docs/adm-guide/media.md
+++ b/docs/adm-guide/media.md
@@ -1,0 +1,32 @@
+---
+tags:
+   - Media
+
+---
+# Manage Media Files
+
+Media files are the images and assets used inside your messages. They belong to
+an <glossary:Application> (and optionally to a project and organization) and are
+referenced from <glossary:Message> content, e.g. `[[media:logo.png]]`.
+
+## Media list
+
+The list at <https://SERVER_ADDRESS/admin/bitcaster/mediafile/> shows a preview
+of every file with its name, size, file type and mime type. Use the filters
+(organization, project, application) to scope the list.
+
+## Upload a media file
+
+1. Go to the media list of the application
+1. Click **Add media file**
+1. Select the **application** the file belongs to and pick the file
+1. Save
+
+The file is stored on the configured media storage (`STORAGE_MEDIA`) and
+served through the media URL.
+
+## Use in messages
+
+Reference the file in a <glossary:Message> template with the `[[media:...]]`
+syntax; the documentation link processor resolves it to the media URL at render
+time.

--- a/docs/adm-guide/member.md
+++ b/docs/adm-guide/member.md
@@ -1,0 +1,34 @@
+---
+tags:
+   - Member
+
+---
+# Manage Members
+
+Members are the users that belong to your organization. Membership is what
+gives a user a role in the organization and makes them a potential recipient
+of its notifications: a user can be member of multiple organizations with a
+different role in each.
+
+## Member list
+
+The member list at <https://SERVER_ADDRESS/admin/bitcaster/member/> shows all
+users and the organization they belong to.
+
+## Member detail
+
+Open a member to manage:
+
+- **Addresses** — the addresses (email, phone, ...) of the user; each address
+  can be validated and assigned to a channel
+- **Assignments** — the <glossary:Assignment>s of the user: which address is
+  used on which <glossary:Channel> and whether it is active
+- **Subscriptions** — the notifications the user subscribed to directly
+- **Distribution lists** — the <glossary:Distribution List>s the member belongs to
+- **Groups and roles** — permissions assigned to the user
+
+## Import members
+
+Use the **Import members** action to bulk-create members from a CSV file
+instead of adding them one by one. The import supports the name, username and
+email columns and reports the errors found in the file.

--- a/docs/adm-guide/message.md
+++ b/docs/adm-guide/message.md
@@ -1,5 +1,12 @@
 # Create Messages
 
+A **Message** is the content the recipients see: the subject and the body
+(plain text and HTML) of a notification, rendered for one specific
+<glossary:Channel>. Each channel enabled for the event needs its own message,
+so an email message can be worded differently from a Slack one. The rendered
+content is snapshotted when a delivery is created, so editing a message later
+never changes messages that are already queued.
+
 Select the notification you want to configure from [Notification list page](<https://SERVER_ADDRESS/admin/bitcaster/notification/>){ target=_app } and click on `messages`{ .bc-tool-button .link }
 
 ![Image](_screenshots/notification/messages.png)

--- a/docs/adm-guide/occurrence.md
+++ b/docs/adm-guide/occurrence.md
@@ -1,0 +1,53 @@
+---
+tags:
+   - Occurrence
+
+---
+# Work with Occurrences
+
+An <glossary:Occurrence> is created every time an <glossary:Event> is triggered.
+It is the audit trail of a single delivery attempt: it stores the context sent
+by the caller, which recipients were selected, which messages were rendered
+and the final outcome. Occurrences let you verify that notifications actually
+happened and debug routing issues without guessing.
+
+## Occurrence list
+
+Every triggered occurrence appears in the list at
+<https://SERVER_ADDRESS/admin/bitcaster/occurrence/> with:
+
+- **timestamp** — when the occurrence was created
+- **application / event** — the source of the trigger
+- **status** — `NEW` (waiting to be processed), `PROCESSED` or `FAILED`
+- **attempts** — remaining processing attempts before the occurrence is marked as failed
+- **recipients** — number of recipients reached
+
+Use the filters (time range, application, event, status) to narrow the list.
+
+## Occurrence detail
+
+Open an occurrence to inspect what happened. The change page is organised in tabs:
+
+- **General** — timestamp, event and newsletter mode
+- **Process** — attempts left and current status
+- **Input** — correlation id, the context payload and the routing options sent by the caller
+- **Delivery** — number of recipients and the processing data (recipients, channels, errors, rendered content)
+
+## Inspect
+
+The **Inspect** button runs a dry-run of the recipient pipeline: it collects and
+renders the recipients without sending anything, so you can verify context and
+templates before the real send.
+
+## Recipients
+
+From an occurrence you can navigate to the recipients page to see which
+<glossary:Assignment>s were selected and for which channel.
+
+## Purge
+
+Occurrences older than the configured retention are purged automatically. The
+**Purge occurrences** action in the admin sidebar removes them immediately.
+
+Occurrences whose event did not reach any recipient trigger the
+`OCCURRENCE_SILENCE` system event, so you can monitor silent events.

--- a/docs/adm-guide/process_log.md
+++ b/docs/adm-guide/process_log.md
@@ -1,0 +1,27 @@
+---
+tags:
+   - Process
+
+---
+# Process Log
+
+The Process Log page lists the executions of the background tasks (dramatiq
+actors) that Bitcaster runs: processing occurrences, purging old records,
+checking monitors and so on. It answers the question "did the background job
+run and did it succeed?" without digging into the workers' logs.
+
+## Process log list
+
+The list at <https://SERVER_ADDRESS/admin/bitcaster/processlogentry/> shows for
+each execution:
+
+- **action time** — when the task ran
+- **status** — whether it succeeded or failed
+- **elapsed** — how long the task took
+- **task name** — the actor that ran
+
+Use the **Type** filter to show only the executions of a specific task.
+
+The log is **read-only**: it is written by the background manager and cannot be
+modified from the admin. Failed executions here are usually the first symptom
+of a misconfigured task, channel or dispatcher.

--- a/docs/adm-guide/stream.md
+++ b/docs/adm-guide/stream.md
@@ -1,0 +1,24 @@
+---
+tags:
+   - Stream
+
+---
+# Stream
+
+The Stream page shows the log messages produced by the Bitcaster applications in
+real time. It is the first place to look when something goes wrong with an
+<glossary:Event> or a dispatcher.
+
+## Stream list
+
+The list at <https://SERVER_ADDRESS/admin/bitcaster/logmessage/> shows every
+message with:
+
+- **created** — when the message was logged
+- **level** — the log severity (`INFO`, `WARNING`, `ERROR`, ...)
+- **application** — the application that produced the message
+
+Filter by level or application to find what you are looking for.
+
+The stream is **read-only**: messages are written by the system and cannot be
+added or edited from the admin.

--- a/docs/adm-guide/structure.md
+++ b/docs/adm-guide/structure.md
@@ -1,3 +1,12 @@
+# Create the Initial Structure
+
+Bitcaster organises everything in a three-level hierarchy: an
+<glossary:Organization> is the top-level tenant (usually the company), a
+<glossary:Project> groups the applications of a business unit, product line or
+team, and an <glossary:Application> (see [Add Application](app.md)) hosts the
+events, notifications and channels of one product. Organization-wide settings
+and abstract channels live at the top, while projects scope their own
+channels, distribution lists and members.
 
 Before we can start triggering events in Bitcaster we need to create the initial structure
 

--- a/docs/adm-guide/subscription.md
+++ b/docs/adm-guide/subscription.md
@@ -1,0 +1,31 @@
+---
+tags:
+   - Subscription
+
+---
+# Manage Subscriptions
+
+A Subscription lets a user listen to a <glossary:Notification> directly, without
+being part of any <glossary:Distribution List>.
+
+The user is derived from the address of the subscribed
+<glossary:Assignment>, so the assignment must exist and be active on the
+channel the notification is delivered on.
+
+Subscriptions are the recipient source for notifications using the
+`FILTERING_SUBSCRIPTION` policy.
+
+## Subscription list
+
+The list at <https://SERVER_ADDRESS/admin/bitcaster/subscription/> shows every
+subscription with its notification, the assignment used to receive it and
+whether it is active.
+
+## Add or edit a subscription
+
+1. Select the **notification** the user wants to listen to
+1. Select the **assignment** that carries the address that will receive the message
+1. Keep **active** checked to enable the subscription
+
+Disable the **active** flag (or delete the subscription) to stop the user from
+receiving that notification.

--- a/docs/adm-guide/system_log.md
+++ b/docs/adm-guide/system_log.md
@@ -1,0 +1,26 @@
+---
+tags:
+   - Log
+
+---
+# System Log
+
+The System Log page shows the audit trail of every action performed in the
+admin interface: who added, changed or deleted which object and when.
+
+## System log list
+
+The list at <https://SERVER_ADDRESS/admin/bitcaster/logentry/> shows for each
+entry:
+
+- **action time** — when the action was performed
+- **user** — who performed it
+- **content type** — the type of object affected
+- **object** — the object that was added, changed or deleted
+- **change message** — the summary of the change (e.g. changed fields)
+
+The log is written automatically by Django and is **read-only**: entries cannot
+be added or edited from the admin.
+
+Use it to answer questions like "who changed this application last week?" or
+"when was this channel deactivated?".

--- a/docs/adm-guide/tasks.md
+++ b/docs/adm-guide/tasks.md
@@ -1,0 +1,36 @@
+---
+tags:
+   - Task
+
+---
+# Schedule Tasks
+
+Tasks let you run background jobs on a schedule: trigger an <glossary:Event>
+periodically, purge old <glossary:Occurrence>s, refresh a monitor and so on.
+
+## Task list
+
+The list at <https://SERVER_ADDRESS/admin/bitcaster/task/> shows the name, the
+function, the scheduling and whether the task is active.
+
+## Add a task
+
+1. Click **Add task**
+1. Provide a **name** and a **slug**
+1. Set **func** to the fully qualified name of the dramatiq actor to run
+   (e.g. `bitcaster.runner.tasks.scan_occurrences`)
+1. Optionally add **args** and **kwargs** passed to the function
+1. Choose the **trigger** type and its configuration:
+   - **interval** — run every N seconds/minutes/hours/days
+   - **cron** — run according to a crontab expression
+   - **date** — run once at a given time
+1. Save
+
+## Run and monitor
+
+- **active** — enable or disable the task without deleting it
+- **next run time** — when the task will run next (update it to reschedule)
+- **replace existing** — replace a running instance with the same id
+- **max instances** — maximum number of concurrent instances
+
+Executions are recorded in the [Process Log](process_log.md).

--- a/docs/adm-guide/user_management.md
+++ b/docs/adm-guide/user_management.md
@@ -1,5 +1,11 @@
 # User Management and Integration
 
+A **User** is a person that can log into Bitcaster and/or receive
+notifications. Users are global to the installation: being member of an
+organization (see [Manage Members](member.md)) gives them a role there and
+lets them hold the <glossary:Address>es — email, phone, ... — through which
+they can be reached by notifications.
+
 Managing users in Bitcaster can be done manually, via bulk imports, or through continuous integration with external systems (like HRIS, CRM, or Custom Apps) using the API.
 
 ---

--- a/src/bitcaster/config/__init__.py
+++ b/src/bitcaster/config/__init__.py
@@ -39,7 +39,7 @@ CONFIG: "Mapping[str, ConfigItem]" = {
     "AUTHENTICATION_BACKENDS": (list, [], setting("authentication-backends")),
     "BITCASTER_DOCUMENTATION_SITE_URL": (
         str,
-        "https://bitcaster-io.github.io/bitcaster",
+        "https://docs.bitcaster.io",
         "Bitcaster documentation site. (no trailing slash)",
     ),
     "CACHE_PREFIX": (str, "", "", "prefix string to use in cache keys"),

--- a/src/bitcaster/config/fragments/help.py
+++ b/src/bitcaster/config/fragments/help.py
@@ -1,0 +1,3 @@
+from bitcaster.config import env
+
+BITCASTER_DOCUMENTATION_SITE_URL = env("BITCASTER_DOCUMENTATION_SITE_URL")

--- a/src/bitcaster/config/settings.py
+++ b/src/bitcaster/config/settings.py
@@ -84,6 +84,7 @@ INSTALLED_APPS = [
     "anymail",
     "bitcaster.apps.Config",
     "bitcaster.console.apps.Config",
+    "bitcaster.help.apps.Config",
     "bitcaster.pwa.apps.Config",
     "tailwind",
     "issues",
@@ -263,6 +264,7 @@ from .fragments.csp import *  # noqa
 from .fragments.debug_toolbar import *  # noqa
 from .fragments.dramatiq import *  # noqa
 from .fragments.flags import *  # noqa
+from .fragments.help import *  # noqa
 from .fragments.logging import *  # noqa
 from .fragments.pwa import *  # noqa
 from .fragments.rest_framework import *  # noqa

--- a/src/bitcaster/help/apps.py
+++ b/src/bitcaster/help/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    name = "bitcaster.help"
+    verbose_name = "Help"
+
+    def ready(self) -> None:
+        from . import checks  # noqa

--- a/src/bitcaster/help/checks.py
+++ b/src/bitcaster/help/checks.py
@@ -1,0 +1,54 @@
+from typing import Any
+
+import re
+from pathlib import Path
+
+from django.apps import AppConfig
+from django.conf import settings
+from django.core import checks
+
+from .links import HELP_LINKS
+
+E001 = checks.Error(
+    "Doc path '%s' does not resolve to an existing source page under docs/",
+    id="bitcaster.help.E001",
+)
+
+E002 = checks.Error(
+    "Doc path '%s' is not a valid relative path (no leading slash, no '#', no '.md')",
+    id="bitcaster.help.E002",
+)
+
+E003 = checks.Error(
+    "Help link regex '%s' is invalid: %s",
+    id="bitcaster.help.E003",
+)
+
+
+def _validate_doc_path(doc_path: str, docs_root: Path) -> list[checks.CheckMessage]:
+    if doc_path.startswith("/") or "#" in doc_path or doc_path.endswith(".md"):
+        return [checks.Error(E002.msg % doc_path, id=E002.id)]
+    page = doc_path.rstrip("/")
+    leaf = docs_root / f"{page}.md"
+    section = docs_root / page
+    if leaf.is_file():
+        return []
+    if section.is_dir() and ((section / ".pages").is_file() or (section / "index.md").is_file()):
+        return []
+    return [checks.Error(E001.msg % doc_path, id=E001.id)]
+
+
+@checks.register("help")
+def check_help_links(app_configs: AppConfig, **kwargs: Any) -> list[checks.CheckMessage]:
+    errors: list[checks.CheckMessage] = []
+    docs_root = Path(settings.PROJECT_ROOT) / "docs"
+    if not docs_root.is_dir():
+        return errors
+    for pattern, doc_path in HELP_LINKS.items():
+        try:
+            re.compile(pattern)
+        except re.error as e:
+            errors.append(checks.Error(E003.msg % (pattern, e), id=E003.id))
+            continue
+        errors.extend(_validate_doc_path(doc_path, docs_root))
+    return errors

--- a/src/bitcaster/help/links.py
+++ b/src/bitcaster/help/links.py
@@ -1,0 +1,63 @@
+from typing import Final
+
+import re
+
+HELP_LINKS: Final[dict[str, str]] = {
+    "^/admin/$": "adm-guide/quickstart/",
+    "^/admin/bitcaster/application": "adm-guide/app/",
+    "^/admin/bitcaster/event": "adm-guide/events/",
+    "^/admin/bitcaster/eventsimulation": "adm-guide/events/",
+    "^/admin/bitcaster/deliverysimulation": "adm-guide/events/",
+    "^/admin/bitcaster/notification": "adm-guide/notification/",
+    "^/admin/bitcaster/messagetemplate": "adm-guide/message/",
+    "^/admin/bitcaster/channel": "adm-guide/abstract_channel_create/",
+    "^/admin/bitcaster/monitor": "adm-guide/monitor/",
+    "^/admin/bitcaster/apikey": "adm-guide/api_key/",
+    "^/admin/bitcaster/distributionlist": "adm-guide/dl/",
+    "^/admin/bitcaster/user": "adm-guide/user_management/",
+    "^/admin/bitcaster/userrole": "adm-guide/user_management/",
+    "^/admin/bitcaster/usermessage": "adm-guide/dispatchers/user_message/",
+    "^/admin/bitcaster/organization": "adm-guide/structure/",
+    "^/admin/bitcaster/project": "adm-guide/structure/",
+    "^/admin/bitcaster/assignment": "adm-guide/notification_policies/",
+    "^/admin/bitcaster/occurrence": "adm-guide/occurrence/",
+    "^/admin/bitcaster/member": "adm-guide/member/",
+    "^/admin/bitcaster/subscription": "adm-guide/subscription/",
+    "^/admin/bitcaster/address": "adm-guide/address/",
+    "^/admin/bitcaster/attachment": "adm-guide/attachment/",
+    "^/admin/bitcaster/mediafile": "adm-guide/media/",
+    "^/admin/bitcaster/logmessage": "adm-guide/stream/",
+    "^/admin/bitcaster/processlogentry": "adm-guide/process_log/",
+    "^/admin/bitcaster/task": "adm-guide/tasks/",
+    "^/admin/bitcaster/logentry": "adm-guide/system_log/",
+    "^/admin/flags/flagstate": "adm-guide/flags/",
+    "^/admin/constance/config": "configuration/",
+    "^/admin/auth/group": "adm-guide/user_management/",
+    "^/admin/": "adm-guide/quickstart/",
+    "^/console/": "adm-guide/cli/",
+}
+
+_COMPILED: Final[list[tuple[re.Pattern[str], str]]] = [
+    (re.compile(pattern), doc_path) for pattern, doc_path in HELP_LINKS.items()
+]
+
+
+def resolve_help_path(path: str) -> str | None:
+    best: tuple[int, int, int] | None = None
+    result: str | None = None
+    for idx, (pattern, doc_path) in enumerate(_COMPILED):
+        match = pattern.match(path)
+        if match is None:
+            continue
+        candidate = (len(match.group(0)), len(pattern.pattern), -idx)
+        if best is None or candidate > best:
+            best = candidate
+            result = doc_path
+    return result
+
+
+def resolve_help_url(path: str, doc_site: str) -> str | None:
+    doc_path = resolve_help_path(path)
+    if doc_path is None or not doc_site:
+        return None
+    return f"{doc_site.rstrip('/')}/{doc_path}"

--- a/src/bitcaster/help/templatetags/help.py
+++ b/src/bitcaster/help/templatetags/help.py
@@ -1,0 +1,34 @@
+from typing import TYPE_CHECKING, Any
+
+from django import template
+from django.conf import settings
+from django.utils.html import escape
+from django.utils.safestring import mark_safe
+from django.utils.translation import gettext as _
+
+from ..links import resolve_help_url
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True, name="help")
+def help_tag(context: dict[str, Any]) -> str:
+    request: "HttpRequest | None" = context.get("request")
+    if request is None or context.get("is_popup"):
+        return ""
+    doc_site = settings.BITCASTER_DOCUMENTATION_SITE_URL
+    if not doc_site:
+        return ""
+    url = resolve_help_url(request.path, doc_site)
+    if url is None:
+        return ""
+    label = escape(_("Documentation"))
+    return mark_safe(  # nosec: B703 B308  # noqa: S308 - values escaped above, markup is static
+        '<a class="block cursor-pointer h-[18px] hover:text-base-700 dark:hover:text-base-200" '
+        f'href="{escape(url)}" target="_blank" rel="noopener" '
+        f'title="{label}" aria-label="{label}">'
+        '<span class="material-symbols-outlined">help</span></a>'
+    )

--- a/src/bitcaster/utils/markdown.py
+++ b/src/bitcaster/utils/markdown.py
@@ -7,7 +7,7 @@ from markdown import Markdown
 from markdown.extensions import Extension
 from markdown.inlinepatterns import InlineProcessor
 
-from bitcaster.config import env
+from django.conf import settings
 
 
 def build_url(base: str, path: str) -> str:
@@ -37,7 +37,7 @@ class LinksInlineProcessor(InlineProcessor):
 class BitcasterDocSiteExtension(Extension):
     def __init__(self, **kwargs: Any):
         self.config = {
-            "base_url": [env("BITCASTER_DOCUMENTATION_SITE_URL"), ""],
+            "base_url": [settings.BITCASTER_DOCUMENTATION_SITE_URL, ""],
         }
         super().__init__(**kwargs)
 

--- a/src/bitcaster/web/context_processors.py
+++ b/src/bitcaster/web/context_processors.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING, Any
 
+from django.conf import settings
 from django.template.context_processors import debug as django_debug
 
 from bitcaster import VERSION
-from bitcaster.config import env
 
 if TYPE_CHECKING:
     from django.http import HttpRequest
@@ -13,7 +13,7 @@ def version(request: "HttpRequest") -> dict[str, dict[str, str]]:
     return {
         "bitcaster": {
             "version": VERSION,
-            "doc_site": env("BITCASTER_DOCUMENTATION_SITE_URL"),
+            "doc_site": settings.BITCASTER_DOCUMENTATION_SITE_URL,
         }
     }
 

--- a/src/bitcaster/web/templates/bitcaster/console/base.html
+++ b/src/bitcaster/web/templates/bitcaster/console/base.html
@@ -1,5 +1,5 @@
 {% extends "bitcaster/base.html" %}
-{% load feature_flags i18n static user %}
+{% load feature_flags help i18n static user %}
 {% block bodyclass %}
     pwa
 {% endblock %}
@@ -37,6 +37,7 @@
                     <span class="material-symbols-outlined text-[24px]" x-show="adminTheme !== 'dark'">light_mode</span>
                     <span class="material-symbols-outlined text-[24px]" x-show="adminTheme === 'dark'">dark_mode</span>
                 </button>
+                {% help %}
             </div>
         </div>
     {% endblock %}

--- a/src/bitcaster/web/templates/unfold/helpers/userlinks.html
+++ b/src/bitcaster/web/templates/unfold/helpers/userlinks.html
@@ -1,8 +1,9 @@
-{% load i18n static %}
+{% load i18n static help %}
 <div class="flex items-center ml-auto">
     <div class="flex flex-row group items-center leading-none relative">
         <div class="flex gap-4 items-center mr-4">
             {% include "bitcaster/unfold/consoles.html" %}
+            {% help %}
             {% if environment %}
                 {% include "unfold/helpers/label.html" with text=environment.0 type=environment.1 %}
             {% endif %}

--- a/tests/help/test_help_checks.py
+++ b/tests/help/test_help_checks.py
@@ -1,0 +1,80 @@
+# mypy: disable-error-code="attr-defined"
+from typing import Any
+
+from pathlib import Path
+
+import pytest
+
+from django.core import checks as django_checks
+from django.test import override_settings
+
+from bitcaster.help.checks import E001, E002, E003
+
+
+def _errors(monkeypatch: pytest.MonkeyPatch, links: dict[str, str], tmp_path: Path) -> list[Any]:
+    from bitcaster.help import checks as help_checks
+
+    monkeypatch.setattr(help_checks, "HELP_LINKS", links)
+    with override_settings(PROJECT_ROOT=str(tmp_path)):
+        return django_checks.run_checks(tags=["help"])
+
+
+def test_valid_mapping_no_errors() -> None:
+    assert django_checks.run_checks(tags=["help"]) == []
+
+
+def test_missing_doc_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    (tmp_path / "docs").mkdir()
+    errors = _errors(monkeypatch, {"^/x/": "adm-guide/app/"}, tmp_path)
+    assert [e.id for e in errors] == [E001.id]
+
+
+def test_leaf_page_via_md_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    (docs / "adm-guide").mkdir(parents=True)
+    (docs / "adm-guide" / "app.md").write_text("# App")
+    assert _errors(monkeypatch, {"^/x/": "adm-guide/app/"}, tmp_path) == []
+
+
+def test_section_page_via_pages_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    (docs / "adm-guide").mkdir(parents=True)
+    (docs / "adm-guide" / ".pages").write_text("")
+    assert _errors(monkeypatch, {"^/x/": "adm-guide/"}, tmp_path) == []
+
+
+def test_section_page_via_index_md(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    (docs / "adm-guide").mkdir(parents=True)
+    (docs / "adm-guide" / "index.md").write_text("# Guide")
+    assert _errors(monkeypatch, {"^/x/": "adm-guide/"}, tmp_path) == []
+
+
+@pytest.mark.parametrize(
+    "doc_path",
+    [
+        pytest.param("/absolute/", id="leading-slash"),
+        pytest.param("adm-guide/app#anchor/", id="anchor"),
+        pytest.param("adm-guide/app.md", id="md-extension"),
+    ],
+)
+def test_invalid_doc_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, doc_path: str) -> None:
+    (tmp_path / "docs").mkdir()
+    errors = _errors(monkeypatch, {"^/x/": doc_path}, tmp_path)
+    assert [e.id for e in errors] == [E002.id]
+
+
+def test_invalid_regex(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    (tmp_path / "docs").mkdir()
+    errors = _errors(monkeypatch, {"[": "adm-guide/app/"}, tmp_path)
+    assert [e.id for e in errors] == [E003.id]
+
+
+def test_skipped_when_docs_dir_absent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    assert _errors(monkeypatch, {"^/x/": "adm-guide/app/"}, tmp_path) == []
+
+
+def test_root_checks_module_untouched() -> None:
+    root_checks = Path(__file__).resolve().parents[2] / "src" / "bitcaster" / "checks.py"
+    content = root_checks.read_text()
+    assert "bitcaster.help." not in content

--- a/tests/help/test_links.py
+++ b/tests/help/test_links.py
@@ -1,0 +1,129 @@
+# mypy: disable-error-code="attr-defined"
+
+import re
+
+import pytest
+
+from bitcaster.help.links import HELP_LINKS, resolve_help_path, resolve_help_url
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        pytest.param("/admin/", "adm-guide/quickstart/", id="admin-index"),
+        pytest.param("/admin/bitcaster/application/", "adm-guide/app/", id="application-changelist"),
+        pytest.param("/admin/bitcaster/application/1/change/", "adm-guide/app/", id="application-change"),
+        pytest.param("/admin/bitcaster/event/", "adm-guide/events/", id="event"),
+        pytest.param("/admin/bitcaster/notification/", "adm-guide/notification/", id="notification"),
+        pytest.param("/admin/bitcaster/channel/", "adm-guide/abstract_channel_create/", id="channel"),
+        pytest.param("/admin/bitcaster/monitor/", "adm-guide/monitor/", id="monitor"),
+        pytest.param("/admin/bitcaster/apikey/", "adm-guide/api_key/", id="apikey"),
+        pytest.param("/admin/bitcaster/distributionlist/", "adm-guide/dl/", id="distribution"),
+        pytest.param("/admin/bitcaster/messagetemplate/", "adm-guide/message/", id="message"),
+        pytest.param("/admin/bitcaster/organization/", "adm-guide/structure/", id="organization"),
+        pytest.param("/admin/bitcaster/project/", "adm-guide/structure/", id="project"),
+        pytest.param("/admin/bitcaster/assignment/", "adm-guide/notification_policies/", id="assignment"),
+        pytest.param("/admin/bitcaster/occurrence/", "adm-guide/occurrence/", id="occurrence"),
+        pytest.param("/admin/bitcaster/member/", "adm-guide/member/", id="member"),
+        pytest.param("/admin/bitcaster/subscription/", "adm-guide/subscription/", id="subscription"),
+        pytest.param("/admin/bitcaster/address/", "adm-guide/address/", id="address"),
+        pytest.param("/admin/bitcaster/attachment/", "adm-guide/attachment/", id="attachment"),
+        pytest.param("/admin/bitcaster/mediafile/", "adm-guide/media/", id="mediafile"),
+        pytest.param("/admin/bitcaster/logmessage/", "adm-guide/stream/", id="logmessage"),
+        pytest.param("/admin/bitcaster/processlogentry/", "adm-guide/process_log/", id="processlogentry"),
+        pytest.param("/admin/bitcaster/task/", "adm-guide/tasks/", id="task"),
+        pytest.param("/admin/bitcaster/logentry/", "adm-guide/system_log/", id="logentry"),
+        pytest.param("/admin/flags/flagstate/", "adm-guide/flags/", id="flags"),
+        pytest.param("/admin/constance/config/", "configuration/", id="constance"),
+        pytest.param("/admin/auth/group/", "adm-guide/user_management/", id="group"),
+        pytest.param("/admin/bitcaster/whatever/", "adm-guide/quickstart/", id="unmapped-model-fallback"),
+        pytest.param("/admin/social/socialaccount/", "adm-guide/quickstart/", id="third-party-fallback"),
+        pytest.param("/console/", "adm-guide/cli/", id="console"),
+        pytest.param("/console/1/", "adm-guide/cli/", id="console-detail"),
+    ],
+)
+def test_exact_match(path: str, expected: str) -> None:
+    assert resolve_help_path(path) == expected
+
+
+def test_weighted_strictest_wins() -> None:
+    assert resolve_help_path("/admin/bitcaster/event/1/change/") == "adm-guide/events/"
+    assert resolve_help_path("/admin/bitcaster/event/") == "adm-guide/events/"
+    assert resolve_help_path("/admin/") == "adm-guide/quickstart/"
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        pytest.param("/admin/bitcaster/eventsimulation/", "adm-guide/events/", id="eventsimulation"),
+        pytest.param("/admin/bitcaster/eventsimulation/1/deliveries/", "adm-guide/events/", id="eventsimulation-sub"),
+        pytest.param("/admin/bitcaster/userrole/", "adm-guide/user_management/", id="userrole"),
+        pytest.param("/admin/bitcaster/usermessage/", "adm-guide/dispatchers/user_message/", id="usermessage"),
+        pytest.param("/admin/bitcaster/user/", "adm-guide/user_management/", id="user"),
+        pytest.param("/admin/bitcaster/deliverysimulation/", "adm-guide/events/", id="deliverysimulation"),
+    ],
+)
+def test_prefix_collisions(path: str, expected: str) -> None:
+    assert resolve_help_path(path) == expected
+
+
+def test_no_match() -> None:
+    assert resolve_help_path("/") is None
+    assert resolve_help_path("/recipients/abc123/") is None
+    assert resolve_help_path("/login/") is None
+
+
+def test_query_strings_ignored() -> None:
+    assert resolve_help_path("/admin/bitcaster/application/?a=1") == "adm-guide/app/"
+
+
+def test_trailing_slash_handled() -> None:
+    assert resolve_help_path("/admin/bitcaster/application") == "adm-guide/app/"
+    assert resolve_help_path("/admin/") == "adm-guide/quickstart/"
+
+
+def test_tie_break_longer_pattern(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bitcaster.help import links
+
+    monkeypatch.setattr(
+        links,
+        "_COMPILED",
+        [(re.compile("^/x/"), "short"), (re.compile("^/x/$"), "long")],
+    )
+    assert resolve_help_path("/x/") == "long"
+
+
+def test_tie_break_declaration_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bitcaster.help import links
+
+    monkeypatch.setattr(
+        links,
+        "_COMPILED",
+        [(re.compile("^/x/"), "first"), (re.compile("^/x/"), "second")],
+    )
+    assert resolve_help_path("/x/anything") == "first"
+
+
+def test_help_url_join() -> None:
+    assert (
+        resolve_help_url("/admin/bitcaster/application/", "https://docs.example.com")
+        == "https://docs.example.com/adm-guide/app/"
+    )
+    assert (
+        resolve_help_url("/admin/bitcaster/application/", "https://docs.example.com/")
+        == "https://docs.example.com/adm-guide/app/"
+    )
+
+
+def test_help_url_empty_doc_site() -> None:
+    assert resolve_help_url("/admin/bitcaster/application/", "") is None
+
+
+def test_help_url_no_match() -> None:
+    assert resolve_help_url("/", "https://docs.example.com") is None
+
+
+def test_every_pattern_matches_something() -> None:
+    assert HELP_LINKS
+    for pattern in HELP_LINKS:
+        assert re.compile(pattern)

--- a/tests/help/test_render.py
+++ b/tests/help/test_render.py
@@ -1,0 +1,58 @@
+# mypy: disable-error-code="attr-defined"
+from typing import TYPE_CHECKING
+
+import pytest
+from testutils.factories import ApplicationFactory
+from testutils.factories.user import SuperUserFactory
+
+from django.urls import reverse
+
+if TYPE_CHECKING:
+    from django_webtest import DjangoTestApp
+    from django_webtest.pytest_plugin import MixinWithInstanceVariables
+
+pytestmark = [pytest.mark.admin, pytest.mark.django_db]
+
+HELP_SITE = "https://docs.bitcaster.io"
+
+
+@pytest.fixture
+def app(django_app_factory: "MixinWithInstanceVariables") -> "DjangoTestApp":
+    django_app = django_app_factory(csrf_checks=False)
+    admin_user = SuperUserFactory(username="superuser")
+    django_app.set_user(admin_user)
+    django_app._user = admin_user
+    return django_app
+
+
+def test_admin_index_contains_link(app: "DjangoTestApp") -> None:
+    res = app.get(reverse("admin:index"))
+    assert res.status_code == 200
+    assert f'href="{HELP_SITE}/adm-guide/quickstart/"' in res
+
+
+def test_admin_changelist_contains_link(app: "DjangoTestApp") -> None:
+    ApplicationFactory()
+    res = app.get(reverse("admin:bitcaster_application_changelist"))
+    assert res.status_code == 200
+    assert f'href="{HELP_SITE}/adm-guide/app/"' in res
+
+
+def test_admin_change_form_contains_link(app: "DjangoTestApp") -> None:
+    application = ApplicationFactory()
+    res = app.get(reverse("admin:bitcaster_application_change", args=[application.pk]))
+    assert res.status_code == 200
+    assert f'href="{HELP_SITE}/adm-guide/app/"' in res
+
+
+def test_admin_popup_has_no_link(app: "DjangoTestApp") -> None:
+    application = ApplicationFactory()
+    res = app.get(reverse("admin:bitcaster_application_change", args=[application.pk]) + "?_popup=1")
+    assert res.status_code == 200
+    assert f'href="{HELP_SITE}' not in res
+
+
+def test_console_contains_link(app: "DjangoTestApp") -> None:
+    res = app.get(reverse("console:index"))
+    assert res.status_code == 200
+    assert f'href="{HELP_SITE}/adm-guide/cli/"' in res

--- a/tests/help/test_settings.py
+++ b/tests/help/test_settings.py
@@ -1,0 +1,38 @@
+# mypy: disable-error-code="attr-defined"
+
+from pytest_django.fixtures import SettingsWrapper
+
+from django.test import RequestFactory
+
+
+def test_doc_site_setting_default() -> None:
+    from django.conf import settings
+
+    assert settings.BITCASTER_DOCUMENTATION_SITE_URL == "https://docs.bitcaster.io"
+
+
+def test_doc_site_setting_from_fragment(settings: SettingsWrapper) -> None:
+    settings.BITCASTER_DOCUMENTATION_SITE_URL = "https://docs.example.com"
+    from django.conf import settings as dj_settings
+
+    assert dj_settings.BITCASTER_DOCUMENTATION_SITE_URL == "https://docs.example.com"
+
+
+def test_version_context_processor_exposes_doc_site(settings: SettingsWrapper) -> None:
+    from bitcaster.web.context_processors import version
+
+    out = version(RequestFactory().get("/"))
+    assert out["bitcaster"]["doc_site"] == "https://docs.bitcaster.io"
+
+    settings.BITCASTER_DOCUMENTATION_SITE_URL = "https://docs.example.com"
+    assert version(RequestFactory().get("/"))["bitcaster"]["doc_site"] == "https://docs.example.com"
+
+
+def test_markdown_extension_uses_doc_site(settings: SettingsWrapper) -> None:
+    from bitcaster.utils.markdown import BitcasterDocSiteExtension
+
+    ext = BitcasterDocSiteExtension()
+    assert ext.getConfigs()["base_url"] == "https://docs.bitcaster.io"
+
+    settings.BITCASTER_DOCUMENTATION_SITE_URL = "https://docs.example.com"
+    assert BitcasterDocSiteExtension().getConfigs()["base_url"] == "https://docs.example.com"

--- a/tests/help/test_tags.py
+++ b/tests/help/test_tags.py
@@ -1,0 +1,41 @@
+# mypy: disable-error-code="attr-defined"
+from typing import Any
+
+from pytest_django.fixtures import SettingsWrapper
+
+from django.template import Context, Template
+from django.test import RequestFactory
+
+
+def _render(path: str, **ctx: Any) -> str:
+    t = Template("{% load help %}{% help %}")
+    context = Context({"request": RequestFactory().get(path), **ctx})
+    return t.render(context)
+
+
+def test_renders_complete_link() -> None:
+    out = _render("/admin/bitcaster/application/")
+    assert 'href="https://docs.bitcaster.io/adm-guide/app/"' in out
+    assert 'target="_blank"' in out
+    assert 'rel="noopener"' in out
+    assert '<span class="material-symbols-outlined">help</span>' in out
+    assert 'title="Documentation"' in out
+    assert 'aria-label="Documentation"' in out
+
+
+def test_renders_nothing_for_unmapped_path() -> None:
+    assert _render("/") == ""
+
+
+def test_renders_nothing_without_request() -> None:
+    t = Template("{% load help %}{% help %}")
+    assert t.render(Context({})) == ""
+
+
+def test_renders_nothing_for_empty_doc_site(settings: SettingsWrapper) -> None:
+    settings.BITCASTER_DOCUMENTATION_SITE_URL = ""
+    assert _render("/admin/bitcaster/application/") == ""
+
+
+def test_renders_nothing_for_popup() -> None:
+    assert _render("/admin/bitcaster/application/", is_popup=True) == ""


### PR DESCRIPTION
## Description

Implements the **Help** feature (spec 005): a `{% help %}` template tag in the admin header linking each admin page to its documentation page.

### Help app (`bitcaster.help`)
- `links.py` — resolves admin URLs to doc pages (`HELP_LINKS`), with `/admin/` fallback to the quickstart
- `templatetags/help.py` — `{% help %}` tag, safe when in popups / no request / no doc site / no match
- `checks.py` — system checks validating all doc paths resolve under the documentation site
- `config/fragments/help.py` — `BITCASTER_DOCUMENTATION_SITE_URL` setting (default `https://docs.bitcaster.io`), `env()` consumers migrated to it

### Documentation coverage
All 30 admin models are now linked from the admin UI to the docs. 10 pages added for the remaining models (occurrence, member, subscription, address, attachment, media, stream, process log, tasks, system log), `.pages` nav updated, `events.md` gains Event Simulations, and every admin page now states the **business purpose** of the model it refers to.

## Tests
71 tests in `tests/help/` (links resolution, tag rendering, settings, system checks). Full tox suite (lint, semgrep, mypy, tests, docs, security, pkg_meta) green.