### PR TITLE
feat(release): append Docker pull link to GitHub release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,3 +46,21 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           attestations: true
+
+  update-release-notes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Append Docker section to release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          BODY="$(gh release view "$TAG" --json body -q .body)"
+          if echo "$BODY" | grep -q '## Docker'; then
+            echo "Docker section already present, skipping"
+            exit 0
+          fi
+          printf '%s\n\n## Docker\n\nPull the image:\n\n```bash\ndocker pull os4d/bitcaster:%s\n```\n\n[View all tags on Docker Hub](https://hub.docker.com/r/os4d/bitcaster/tags)\n' "$BODY" "$TAG" > body.md
+          gh release edit "$TAG" --notes-file body.md

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 [![codecov](https://codecov.io/gh/bitcaster-io/bitcaster/graph/badge.svg?token=kAuZEX5k5o)](https://codecov.io/gh/bitcaster-io/bitcaster)
 [![License](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbitcaster-io%2Fbitcaster%2Fdevelop%2Fpyproject.toml&query=project.license.text&label=license)](https://github.com/bitcaster-io/bitcaster?tab=License-1-ov-file)
 [![Docker](https://img.shields.io/docker/pulls/os4d/bitcaster)](https://hub.docker.com/r/os4d/bitcaster/tags)
+[![PyPI](https://img.shields.io/pypi/v/bitcaster)](https://pypi.org/project/bitcaster/)
+[![GitHub Release](https://img.shields.io/github/v/release/bitcaster-io/bitcaster)](https://github.com/bitcaster-io/bitcaster/releases)
+
 
 Bitcaster is a system-to-user **signal-to-message** notification system.
 


### PR DESCRIPTION
### Changes

- Add `update-release-notes` job to `release.yml` that appends a **Docker** section to the release body on `release: published`
- Section includes the `docker pull os4d/bitcaster:<tag>` command and a Docker Hub link
- Idempotent: skips if the Docker section is already present
- Add PyPI and GitHub Release version badges to README