### PR TITLE
test(docs): add docs link checker and fix broken links

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -66,7 +66,8 @@ lint:
 
 docs:
   - added|modified: './docs/**/*'
-  - modified: '.mkdocs.yml'
+  - modified: './mkdocs.yml'
+  - added|modified: './tests/docs/**'
   - modified: './src/bitcaster/config/__init__.py'
-  - modified: './github/workflows/docs.yml'
-  - modified: './github/file-filters.yml'
+  - modified: './.github/workflows/docs.yml'
+  - modified: './.github/file-filters.yml'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,8 +6,9 @@ on:
       - develop
     paths:
       - 'docs/**'
-      - 'mkdocs.yaml'
-      - './github/workflows/docs.yml'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+      - 'tests/docs/**'
   pull_request:
     branches:
       - develop
@@ -16,8 +17,9 @@ on:
       - synchronize
     paths:
       - 'docs/**'
-      - 'mkdocs.yaml'
-      - './github/workflows/docs.yml'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+      - 'tests/docs/**'
 
   schedule:
     - cron: '37 23 * * 2'
@@ -70,6 +72,22 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs-output
+
+  check-links:
+    name: Check links
+    if: needs.changes.outputs.docs == 'true'
+    needs: changes
+    runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: src/
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+      - run: pip install tox
+      - name: Build docs and check links
+        run: tox -e docs-test
 
   # Deployment job
   deploy:

--- a/docs/.pages
+++ b/docs/.pages
@@ -1,6 +1,6 @@
 nav:
   - Home: index.md
-  - "Quick Start": adm-guide/quickstart.md
+  - "Quick Start": adm-guide/quickstart/
   - Run:
       - Docker: run.md
       - Compose: stacks

--- a/docs/adm-guide/abstract_channel_create.md
+++ b/docs/adm-guide/abstract_channel_create.md
@@ -19,7 +19,7 @@ From the [Organization page](https://SERVER_ADDRESS/admin/bitcaster/organization
 ![Image](_screenshots/channels/template_create.png)
 
 
-1. Provide a name for your channel ad choose one of the available [dispatchers](dispatchers/).
+1. Provide a name for your channel ad choose one of the available [dispatchers](dispatchers/index.md).
 1. After you click `Finish`{.bc-button } you will be asked to provide Dispatcher specific configuration.
 
 

--- a/docs/adm-guide/attachment.md
+++ b/docs/adm-guide/attachment.md
@@ -27,5 +27,5 @@ The API upload endpoint
 
 Recipients receive a signed, expiring download link
 (`/attachment/download/<key>/`) in the message. The key is generated with the
-`SECRET_KEY_SALT` configured in the [Configuration](configuration/) and expires
+`SECRET_KEY_SALT` configured in the [Configuration](../configuration.md) and expires
 after the configured timeout.

--- a/docs/adm-guide/dispatchers/index.md
+++ b/docs/adm-guide/dispatchers/index.md
@@ -1,0 +1,23 @@
+# Dispatchers
+
+A **Dispatcher** is the provider-specific component that physically delivers a
+message to its destination: email via SMTP, Slack via webhook, SMS via Twilio,
+and so on.
+
+The available dispatchers are:
+
+- [Email](email.md)
+- [Gmail](gmail.md)
+- [Log](log.md)
+- [Mailgun](mailgun.md)
+- [Mailjet](mailjet.md)
+- [SendGrid](sendgrid.md)
+- [Slack](slack.md)
+- [Sys](sys.md)
+- [Teams](teams.md)
+- [Twilio](twilio.md)
+- [User Message](user_message.md)
+- [X](x.md)
+
+See [Development Guide: Dispatchers](../../dev-guide/dispatchers.md) for
+details on how to implement a new dispatcher.

--- a/docs/glossary/terms/distribution-list.md
+++ b/docs/glossary/terms/distribution-list.md
@@ -18,5 +18,5 @@ represent users of that specific application and the list can only be used
 by Notifications whose Event belongs to the same Application.
 
 !!! info "See also"
-    [Admin Guide: Distribution Lists](../adm-guide/dl.md) |
-    [API Reference](../api/distribution_lists.md)
+    [Admin Guide: Distribution Lists](../../adm-guide/dl.md) |
+    [API Reference](../../api/distribution_lists.md)

--- a/docs/stacks/.pages
+++ b/docs/stacks/.pages
@@ -1,6 +1,5 @@
 title: Compose
 
 nav:
-    - Simple: simple.md
-    - Full: full.md
+    - Stable: stable.md
     - Development: develop.md

--- a/tests/docs/conftest.py
+++ b/tests/docs/conftest.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import contextlib
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_state() -> None:
+    from bitcaster.state import state
+
+    with contextlib.suppress(AttributeError):
+        del state.app

--- a/tests/docs/test_docs_links.py
+++ b/tests/docs/test_docs_links.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from typing import Iterator
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+from xml.sax.saxutils import quoteattr
+
+import requests
+from lxml import html
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DOCS_CHANGE_PATHS = ("docs/", "mkdocs.yml", "tests/docs/")
+DOCS_TEST_FLAG = "RUN_DOCS_TESTS"
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _docs_changed() -> bool:
+    try:
+        base = _git("merge-base", "origin/develop", "HEAD")
+        changed = _git("diff", "--name-only", base, "HEAD").splitlines()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return True
+    return any(path.startswith(prefix) for path in changed for prefix in DOCS_CHANGE_PATHS)
+
+
+def _can_run() -> bool:
+    if os.getenv(DOCS_TEST_FLAG) == "1":
+        return True
+    return shutil.which("properdocs") is not None and _docs_changed()
+
+
+pytestmark = pytest.mark.skipif(
+    not _can_run(),
+    reason="docs not changed (docs/ or mkdocs.yml) or properdocs not installed",
+)
+
+
+@pytest.fixture(scope="session")
+def docs_site(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    site_dir = tmp_path_factory.mktemp("docs") / "site"
+    env = {**os.environ, "PYTHONPATH": str(PROJECT_ROOT / "src")}
+    subprocess.run(
+        ["properdocs", "build", "-d", str(site_dir)],
+        cwd=PROJECT_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return site_dir
+
+
+SKIP_SCHEMES = ("mailto:", "tel:", "javascript:", "data:")
+SKIP_DIRS = {"_theme"}
+PLACEHOLDER_HOSTS = {"SERVER_ADDRESS", "bitcaster.yourdomain.com"}
+PLACEHOLDER_HOST_RE = re.compile(r"[<>]")
+
+
+def _site_url_path() -> str:
+    content = (PROJECT_ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+    match = re.search(r"^site_url:\s*(\S+)", content, flags=re.MULTILINE)
+    return urlparse(match.group(1)).path.strip("/") if match else ""
+
+
+def _site_url_host() -> str:
+    content = (PROJECT_ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+    match = re.search(r"^site_url:\s*(\S+)", content, flags=re.MULTILINE)
+    return urlparse(match.group(1)).hostname or "" if match else ""
+
+
+def _iter_links(site_dir: Path):
+    for page in sorted(site_dir.rglob("*.html")):
+        if page.relative_to(site_dir).parts[0] in SKIP_DIRS:
+            continue
+        tree = html.parse(str(page))
+        for el in tree.xpath("//a[@href] | //img[@src] | //script[@src] | //link[@href] | //iframe[@src]"):
+            url = el.get("href") or el.get("src")
+            if url:
+                yield page, tree, url
+
+
+def _has_anchor(tree, anchor: str) -> bool:
+    q = quoteattr(anchor)
+    return bool(tree.xpath(f"//*[@id={q}]") or tree.xpath(f"//*[@name={q}]"))
+
+
+def _resolve_target(site_dir: Path, page: Path, path: str, site_url_path: str = "") -> Path | None:
+    path = unquote(path)
+    if path.startswith("/"):
+        if site_url_path and path.lstrip("/").startswith(site_url_path):
+            path = path.lstrip("/")[len(site_url_path) :]
+        target = site_dir / path.lstrip("/")
+    else:
+        target = (page.parent / path).resolve()
+    if target.is_dir():
+        target = target / "index.html"
+    if not target.exists():
+        alt = target.with_suffix(".html")
+        if alt.exists():
+            return alt
+        return None
+    return target
+
+
+def _is_placeholder(url: str) -> bool:
+    host = urlparse(url).hostname
+    return bool(host and (host.upper() in PLACEHOLDER_HOSTS or PLACEHOLDER_HOST_RE.search(host)))
+
+
+def test_internal_links(docs_site: Path) -> None:
+    errors: list[str] = []
+    site_url_path = _site_url_path()
+    for page, tree, url in _iter_links(docs_site):
+        if url.startswith(SKIP_SCHEMES) or url.startswith(("http://", "https://")):
+            continue
+        parsed = urlparse(url)
+        if not parsed.path:
+            if parsed.fragment and not _has_anchor(tree, parsed.fragment):
+                errors.append(f"{page.relative_to(docs_site)}: missing anchor #{parsed.fragment} in same page")
+            continue
+        target = _resolve_target(docs_site, page, parsed.path, site_url_path)
+        if target is None:
+            errors.append(f"{page.relative_to(docs_site)}: broken link {url!r}")
+            continue
+        if parsed.fragment and not _has_anchor(html.parse(str(target)), parsed.fragment):
+            errors.append(
+                f"{page.relative_to(docs_site)}: missing anchor #{parsed.fragment} in {target.relative_to(docs_site)}"
+            )
+    assert not errors, "\n".join(errors)
+
+
+def test_external_links(docs_site: Path) -> None:
+    errors: list[str] = []
+    session = requests.Session()
+    seen: set[str] = set()
+    self_host = _site_url_host()
+    for page, _tree, url in _iter_links(docs_site):
+        if not url.startswith(("http://", "https://")):
+            continue
+        if _is_placeholder(url) or urlparse(url).hostname == self_host:
+            continue
+        if url in seen:
+            continue
+        seen.add(url)
+        try:
+            response = session.get(url, timeout=15, allow_redirects=True, stream=True)
+            response.close()
+            if response.status_code >= 400:
+                errors.append(f"{page.relative_to(docs_site)}: {url} -> HTTP {response.status_code}")
+        except requests.RequestException as exc:
+            errors.append(f"{page.relative_to(docs_site)}: {url} -> {type(exc).__name__}: {exc}")
+    assert not errors, "\n".join(errors)

--- a/tox.ini
+++ b/tox.ini
@@ -115,3 +115,17 @@ commands =
     uv build --sdist -q --out-dir {env_tmp_dir} .
     uvx twine check {env_tmp_dir}{/}*
     uvx check-wheel-contents --ignore W002,W004,W009,W004 {env_tmp_dir}
+
+[testenv:docs-test]
+description = build documentation and check links
+skip_install = false
+pass_env =
+    DYLD_LIBRARY_PATH
+set_env =
+    CACHE_URL = redis://localhost:6379/0
+    DATABASE_URL = sqlite:////tmp/bitcaster-docs-test.db
+    DRAMATIQ_BROKER = redis://localhost:6379/0
+    RUN_DOCS_TESTS = 1
+commands =
+    pytest tests/docs/ --no-cov {posargs:}
+dependency_groups = docs, dev


### PR DESCRIPTION
## Summary

Adds automated link checking for the documentation site: the tests build the docs with properdocs and verify that every internal and external link resolves.

## Changes

- **tests/docs/**: new link-checking tests
  - `test_internal_links`: every relative link/asset resolves in the built site (including anchors)
  - `test_external_links`: every external URL returns HTTP < 400
  - tests skip unless docs content changed (docs/, mkdocs.yml, tests/docs/) or `RUN_DOCS_TESTS=1` is set
  - placeholder hosts (SERVER_ADDRESS, bitcaster.yourdomain.com, <...>) are ignored
- **tox.ini**: new `docs-test` env running the link checks with `--no-cov`
- **.github/workflows/docs.yml**: new `check-links` job (runs when the docs filter matches); fixed stale `mkdocs.yaml`/typo'd `./github` paths
- **.github/file-filters.yml**: fixed docs filter paths, added tests/docs/**

## Docs fixes found by the checker

- `docs/.pages`: Quick Start pointed at `adm-guide/quickstart.md` which 404s on the live site
- `docs/stacks/.pages`: nav entries for deleted `simple.md`/`full.md` pages (404 on live site) → replaced with `stable.md`
- `docs/adm-guide/attachment.md`: wrong relative link to Configuration
- `docs/glossary/terms/distribution-list.md`: wrong relative links to Admin Guide/API Reference
- `docs/adm-guide/abstract_channel_create.md`: linked to dispatchers/ (no index page) → new `adm-guide/dispatchers/index.md` landing page

Verified: `tox -e docs-test` and `tox -e lint` pass locally.