### PR TITLE
fix(ci): set GH_REPO in update-release-notes job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Append Docker section to release notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           TAG="${{ github.event.release.tag_name }}"
           BODY="$(gh release view "$TAG" --json body -q .body)"


### PR DESCRIPTION
## Problem

The `update-release-notes` job in release.yml failed with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The job runs `gh release view`/`gh release edit` but never checks out the repository, so `gh` cannot determine the target repo from git remotes.

## Fix

Set `GH_REPO: ${{ github.repository }}` on the step env — `gh` then targets the correct repo without needing a checkout.

## Follow-up

Once merged, re-run the failed 3.0 release job (`gh run rerun`) so the Docker section gets appended to the 3.0 release notes.