### PR TITLE
ci(docker): build only on release, develop push or manual run

### DIFF
--- a/.github/workflows/dockerize.yml
+++ b/.github/workflows/dockerize.yml
@@ -6,9 +6,7 @@ on:
     types: [published]
   push:
     branches:
-      - '**'  # Trigger on push to any branch
-    tags:
-      - '*'    # Trigger on push to any tag
+      - develop
   workflow_dispatch:
     inputs:
       git_reference:


### PR DESCRIPTION
## Summary

Restrict Docker image builds to the intended triggers only:

- **keep**: `release: published` (new releases)
- **keep**: `workflow_dispatch` (manual, any branch/tag/SHA)
- **keep**: push to `develop`
- **remove**: push to any branch (`'**'`)
- **remove**: push to any tag (`'*'`)

Tag pushes no longer build — releases already fire on tag creation, so this avoids double builds. Feature branches no longer push images to Docker Hub.