### PR TITLE
feat(ui): add memberships link to admin sidebar

### DIFF
--- a/src/bitcaster/config/fragments/unfold.py
+++ b/src/bitcaster/config/fragments/unfold.py
@@ -270,6 +270,12 @@ UNFOLD = {
                         "permission": has_model_permission(model_name="application"),
                     },
                     {
+                        "title": _("Memberships"),
+                        "icon": "view_apps",
+                        "link": reverse_lazy("admin:bitcaster_applicationmembership_changelist"),
+                        "permission": has_model_permission(model_name="applicationmembership"),
+                    },
+                    {
                         "title": _("Projects"),
                         "icon": "view_apps",
                         "link": reverse_lazy("admin:bitcaster_project_changelist"),


### PR DESCRIPTION
## Summary
- Add a "Memberships" entry to the admin sidebar navigation, linking to the application membership changelist.
- Entry is permission-guarded with the same `has_model_permission` pattern used by existing nav items.

## Motivation
Users previously had no direct navigation to the membership management screen from the admin sidebar; it was only reachable from application detail pages.

## Testing
- `tox` suite: lint, semgrep, mypy, docs, security, pkg_meta all pass
- 1821 tests passed; `test_admin_pages_no_missing_static` initially failed with an unrelated selenium browser flake (`NoSuchWindowException`) and passed when re-run in isolation

## Breaking Changes
None