### PR TITLE
Fixes cairo lib warnings during tox docs stage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -79,6 +79,8 @@ skip_install = false
 deps =
 pass_env =
     DYLD_LIBRARY_PATH
+set_env =
+    DYLD_FALLBACK_LIBRARY_PATH = /opt/homebrew/lib:/usr/local/lib
 commands =
     properdocs build {posargs:}
 dependency_groups = docs


### PR DESCRIPTION
Allows graceful fallback when searching Cairo libraries on MacOS:

Resolve the following warnings
```
WARNING -  "cairosvg" Python module is installed, but it crashed with:                                                                                                                                 
           no library called "cairo-2" was found
           no library called "libcairo-2" was found
```
# Legal Boilerplate

Look, I get it.
Contributing to Bitcaster, I retain all rights, title and interest in and to my contributions, and by keeping
this boilerplate intact I confirm that Bitcaster can use, modify, copy, and redistribute my contributions,
under Bitcaster's choice of terms.
