### PR TITLE
feat(api-key): Add publishable API keys with CORS middleware and application scoping

### DIFF
--- a/.ai/best-practices.md
+++ b/.ai/best-practices.md
@@ -1,0 +1,91 @@
+# Project Code Conventions
+
+This document collects the code conventions of the Bitcaster codebase. Each rule states the requirement and the concrete pattern observed in the code. Follow these when writing code.
+
+## Django Models
+
+- **Field attributes order**: within a field definition, attributes must appear in this exact order:
+  `verbose_name`, `on_delete`, `to`, `related_name`, `max_length`, `upload_to`, `choices`, `blank`, `null`, `default`, `db_index`, `db_collation`, `unique`, `editable`, `auto_now`, `auto_now_add`, `chained_field`, `chained_model_field`, other custom args, `validators`, `help_text`.
+  - Exception: for `ForeignKey`, `to` and `on_delete` may precede `verbose_name`.
+  - Exception: `ChoiceArrayField` may start with `base_field`.
+- **`verbose_name` and `help_text` are mandatory on every field** and MUST be wrapped with gettext `_("...")`. Use `gettext_lazy as _` in model bodies.
+- **`choices` must be a callable**: pass `choices=SomeTextChoices.choices` (inner/external `TextChoices`/`IntegerChoices` class) or a `def get_xxx_choices() -> list[tuple]` function — never a literal list/tuple/constant on the field.
+- **Inherit `BitcasterBaseModel`** (provides `version` `IntegerVersionField`, `created` `auto_now_add`, `last_updated` `auto_now`) unless the model has specific needs (`AdminReversable` alone for `Monitor`).
+- **Use the provided mixins** instead of re-implementing: `SlugMixin` (name+slug+`__str__`), `LockMixin` (locked/paused + lock/unlock/pause/resume), `Scoped2Mixin`/`Scoped3Mixin` (org→project→application auto-resolve on `save()` and `clean()`).
+- **No UUID PKs** — use default `BigAutoField` id + `natural_key()` / `get_by_natural_key()` for cross-model identity.
+- **Managers**: one custom manager per model (subclassing `BitcasterBaselManager`), always named `objects`; use `from_queryset` for models needing custom queryset methods; use `ScopedManager` for models with scoped FKs; use `.local()` (not `.objects`) to exclude system-org objects when querying user-facing data.
+- **Meta**: always set `_()`-wrapped `verbose_name`/`verbose_name_plural`; `ordering = ("name",)` as default; `unique_together`/named `UniqueConstraint` for parent-scoped uniqueness; named `Index` for hot query paths; `app_label = "bitcaster"` for models defined outside the main app.
+- **`save()` overrides** for derived data: owner fallback up the hierarchy (`try: self.owner except User.DoesNotExist: self.owner = self.project.owner`), slugify, protocol-from-dispatcher. See `.ai/domain.md` for the ownership cascade.
+
+## Admin
+
+- **All admins inherit `BaseAdmin[Model]`** (which itself composes `BitcasterModelAdmin(UnfoldModelAdmin)` + filters/extra-buttons mixins). One file per model: `admin/<model>.py` with class `{Model}Admin`.
+- **Every `ForeignKey` displayed in the admin MUST be in `autocomplete_fields`** — unless it is in `readonly_fields` or a radio field.
+- **Never expose sensitive fields in `list_display`**: `secret`, `key`, `password`, `token`, `api_key`, `client_secret`, `private_key`, `access_token`, `refresh_token`, `auth_token`, `secret_key`. Reveal secrets only via dedicated button views (e.g. `show_key` with expiry + permission gating), and use `get_exclude` to keep them out of forms.
+- **fieldsets use Unfold tabs**: `{"classes": ["tab"], "fields": [...]}` with `gettext_lazy` titles; separate `add_fieldsets` for the create form.
+- **Derived/display columns**: trailing underscore for scalar methods (`dispatcher_`, `agent_`), `_badge`/`_link` suffix with `unfold.decorators.display` for badges, `@display(boolean=True)` for booleans.
+- **`get_queryset` must `select_related`** FK chains; reuse via `list_select_related`.
+- **System-org protection**: `get_readonly_fields`/`has_*_permission` guards for records owned by the protected `bitcaster` org (see `.ai/domain.md`).
+- **Dynamic initial data** via `get_changeform_initial_data` (owner/user from `request.user`, relations from GET params/cookies).
+- **Actions**: boolean toggles via shared `admin_toggle_bool_action` helper; destructive flows via `confirm_action`; `admin_extra_buttons` decorators (`@button`, `@link`, `@view`, `@choice`) with `ButtonColor` enums.
+
+## Dispatchers
+
+- **Inherit `Dispatcher`**, define `slug`, `verbose_name`, `config_class` (a `forms.Form` subclass named `{Name}Config`), `protocol` (`MessageProtocol`), and optional `backend`.
+- **Every `send` implementation MUST wrap delivery logic in `try...except Exception` raising only `DispatcherError(...) from e`**. The base `Dispatcher.send()` wrapper enforces this; subclass `_send` and let the base wrap, or wrap explicitly.
+- Access validated configuration via `self.config["key"]` (form-validated, raises `ValidationError` on bad config). Never log secrets; use `logger.exception(e)` then re-raise.
+- Full template, config validation, and testing requirements: see `.ai/dispatchers.md`.
+
+## Background Tasks (Dramatiq / runner)
+
+- **Every actor MUST use `@dramatiq.actor(actor_class=SmartActor, ...)`**.
+- **Actor names must stay short** — keep function names under 1000 characters.
+- Use `logging=True` for actors needing `ProcessLogEntry` audit; `max_retries=0` for batch/purge/simulation tasks where retries are harmful.
+- **Enqueue with `.send()`, never `.delay()`**; pass primitive PKs (never ORM objects); re-fetch the object inside the task with `select_related`.
+- **Lazy-import Django models inside task bodies**, never at module top.
+- Error handling: per-item `try/except` with `logger.exception(e)` and continue; catch→record-state→re-raise only when retries should run.
+- Recurring jobs go through APScheduler via the `SCHEDULER` dict in `runner/config.py`.
+- All external calls / heavy processing MUST be offloaded to tasks — never in the request-response cycle (see `.ai/standards.md`).
+
+## Migrations
+
+- **Indexes must be added concurrently**: use `django.contrib.postgres.operations.AddIndexConcurrently`, never `migrations.AddIndex`.
+
+## Type Annotations
+
+- **Modern syntax only** (Python 3.13):
+  - `X | Y` not `Union[X, Y]`; `X | None` not `Optional[X]`
+  - `list[X]`, `dict[K, V]`, `tuple[X, ...]`, `type[X]` — never `List`/`Dict`/`Tuple`/`Type`
+- Mandatory type hints on all new functions (`django-stubs` patterns); classes are generic over their model (`class XAdmin(BaseAdmin[X])`, `ModelSerializer[M]`, `ModelForm[M]`); `TYPE_CHECKING` guards for typing-only imports.
+
+## Imports
+
+- **Relative imports within `src/bitcaster/`**, never absolute `bitcaster.*` imports inside the package.
+- **Relative imports may go up at most 2 levels**; beyond that use absolute imports from the top-level package.
+- isort sections (django, testing, typing, first-party) are configured in `ruff.toml` — `tox -e lint` fixes ordering.
+
+## Testing
+
+- **Never call Factory classes directly in test bodies**: define fixtures that wrap factories (`UserFactory.create()` inside a fixture) and import factories lazily inside the fixture. See `.ai/testing-patterns.md`.
+- Test files mirror `src/` structure; prefixes: `test_d_*` dispatchers, `test_p_*` webpush, `test_f_*` selenium, `test_model_*` models; module-level `pytestmark` lists with `pytest.mark.django_db` etc.
+- HTTP mocking via `mocked_responses` fixture (YAML fixture replay for mailjet); low-level libs via `patch(..., autospec=True)`; freezegun for time-based scenarios.
+- Assert with debug context: `assert res.status_code == ..., res.json()`.
+
+## Logging
+
+- Module-level `logger = logging.getLogger(__name__)` in every module; never `print()`.
+- **Never put exception objects in a logger's `extra` dict** — it can pin thread references (Sentry + asgiref memory leak). Use `str(exc)` or `logger.exception(e)`.
+- `logger.exception(e)` in `except` blocks before handling; `logger.debug` per-item detail, `logger.info` phase summaries, `logger.warning` for recoverable issues (lazy `%s` formatting).
+
+## API (DRF)
+
+- Compose `SecurityMixin` (auth + `ApiApplicationPermission` + grants + throttling + exception handling) — never re-declare DRF defaults.
+- Declare `required_grants = [Grant.X]` on every view; use `@extend_schema` with lazy `_()` descriptions on every handler.
+- Serializers: explicit `fields` tuples, `SerializerMethodField` for derived/nested data, `source=` + `read_only=True` for flattening, per-action serializers via `action_serializers` + `get_serializer_class`.
+- Catch domain exceptions at the view boundary and translate to proper HTTP status with `{"error": str(e)}` payloads — never let domain errors escape as 500s.
+
+## Error Handling
+
+- Domain exceptions live in `bitcaster/exceptions.py`; raise with context: `raise XError(...) from e` inside `except` blocks; `raise forms.ValidationError(...) from None` when wrapping lower-level validation.
+- Business logic lives on models/managers (fat models) with `TypedDict` option contracts; `handlers.py` files are for Django signal wiring only.
+- Filtering/payload rules must pass the shared validators (`validate_schema`, `validate_filters`, `validate_lookups` in `utils/filtering.py`) before being persisted.

--- a/src/bitcaster/admin/api_key.py
+++ b/src/bitcaster/admin/api_key.py
@@ -8,7 +8,6 @@ from adminfilters.autocomplete import LinkedAutoCompleteFilter
 from flags.state import flag_enabled
 
 from django import forms
-from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
@@ -18,6 +17,7 @@ from django.utils.translation import gettext_lazy as _
 from bitcaster.auth.constants import Grant
 from bitcaster.forms.mixins import Scoped3FormMixin
 from bitcaster.models import ApiKey, Application, Event, Organization, Project  # noqa
+from bitcaster.models.key import KeyKind
 from bitcaster.state import state
 from bitcaster.utils.security import is_root
 
@@ -33,12 +33,33 @@ logger = logging.getLogger(__name__)
 
 
 class ApiKeyForm(Scoped3FormMixin[ApiKey], forms.ModelForm[ApiKey]):
+    allowed_events = forms.MultipleChoiceField(
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+        label=_("Restrict to Events"),
+        help_text=_("Events this key can trigger. Empty means any event of the application."),
+    )
+
     class Meta:
         model = ApiKey
-        fields = ("name", "organization", "user", "grants", "environments", "project", "application")
+        fields = (
+            "name",
+            "kind",
+            "organization",
+            "user",
+            "grants",
+            "environments",
+            "project",
+            "application",
+            "origins",
+            "allowed_events",
+        )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+        if self.instance and self.instance.pk and self.instance.application_id:
+            self.fields["allowed_events"].choices = [(e.slug, str(e)) for e in self.instance.application.events.all()]
+            self.fields["allowed_events"].initial = self.instance.allowed_events or []
         if self.instance and self.instance.pk and self.instance.project and self.instance.project.environments:
             choices = [(k, k) for k in self.instance.project.environments]
             self.fields["environments"] = forms.MultipleChoiceField(
@@ -49,20 +70,27 @@ class ApiKeyForm(Scoped3FormMixin[ApiKey], forms.ModelForm[ApiKey]):
 
     def clean(self) -> dict[str, Any]:
         cleaned_data = cast("dict[str, Any]", super().clean())
-        if self.instance.pk is None and (g := cleaned_data.get("grants")):
+        if cleaned_data.get("kind") == KeyKind.PUBLIC:
+            cleaned_data["grants"] = [Grant.EVENT_TRIGGER]
+            if not cleaned_data.get("application"):
+                self.add_error("application", _("Public keys must be pinned to an application"))
+            if not cleaned_data.get("origins"):
+                self.add_error("origins", _("Public keys must declare at least one allowed origin"))
+        elif self.instance.pk is None and (g := cleaned_data.get("grants")):
             a = cleaned_data.get("application")
             if Grant.EVENT_TRIGGER in g and not a:
-                raise ValidationError(_("Application must be set if EVENT_TRIGGER is granted"))
+                self.add_error("application", _("Application must be set if EVENT_TRIGGER is granted"))
         return cleaned_data
 
 
 class ApiKeyAdmin(BaseAdmin[ApiKey]):
     search_fields = ("name",)
-    list_display = ("name", "user", "organization", "project", "application", "environments")
+    list_display = ("name", "kind", "user", "organization", "project", "application", "environments")
     list_filter = (
         ("organization", LinkedAutoCompleteFilter.factory(parent=None)),
         ("project", LinkedAutoCompleteFilter.factory(parent="organization")),
         ("application", LinkedAutoCompleteFilter.factory(parent="project")),
+        "kind",
         EnvironmentFilter,
     )
     autocomplete_fields = ("user", "application", "organization", "project")
@@ -72,6 +100,12 @@ class ApiKeyAdmin(BaseAdmin[ApiKey]):
 
     def get_queryset(self, request: HttpRequest) -> "QuerySet[ApiKey]":
         return super().get_queryset(request).select_related("application")
+
+    def get_fields(self, request: HttpRequest, obj: ApiKey | None = None) -> "_ListOrTuple[str]":
+        fields = super().get_fields(request, obj)
+        if obj is None or not obj.application_id:
+            fields = [f for f in fields if f != "allowed_events"]
+        return fields
 
     def get_readonly_fields(self, request: HttpRequest, obj: ApiKey | None = None) -> list[str]:
         if obj and obj.pk:

--- a/src/bitcaster/api/event.py
+++ b/src/bitcaster/api/event.py
@@ -14,6 +14,7 @@ from .base import SecurityMixin
 from ..auth.constants import Grant
 from ..exceptions import InactiveError, LockError
 from ..models import Application, Event, LogEntry, Occurrence, User
+from ..models.key import KeyKind
 from ..utils.filtering import validate_filters, validate_lookups, validate_schema
 
 if TYPE_CHECKING:
@@ -119,6 +120,8 @@ class EventTrigger(SecurityMixin, GenericAPIView[Event]):
             slug = self.kwargs["evt"]
             create_occurrence = True
             try:
+                if error := self._check_public_key_request(request, slug, ser.validated_data):
+                    return error
                 data: dict[str, "JSONValue"] = {}
                 try:
                     evt: "Event" = self.get_queryset().get(slug=slug)
@@ -205,3 +208,23 @@ class EventTrigger(SecurityMixin, GenericAPIView[Event]):
                 return Response({"error": f"Event not found {self.kwargs}"}, status=404)
         else:
             return Response(ser.errors, status=400)
+
+    def _check_public_key_request(self, request: "Request", slug: str, payload: dict[str, Any]) -> "Response | None":
+        """Enforce restricted trigger semantics for PUBLIC keys.
+
+        Public keys cannot target specific recipients or filter users (user
+        enumeration) and can only use scalar context values.
+        """
+        if getattr(request.auth, "kind", KeyKind.SERVER) != KeyKind.PUBLIC:
+            return None
+        opts_raw = payload.get("options", {})
+        if "limit_to" in opts_raw or "filters" in opts_raw:
+            return Response(
+                {"error": "options 'limit_to' and 'filters' are not allowed for public keys"},
+                status=400,
+            )
+        if request.auth.allowed_events and slug not in request.auth.allowed_events:
+            return Response({"error": f"Event not allowed for this key: {slug}"}, status=403)
+        if any(not isinstance(v, str | int | float | bool) for v in payload.get("payload_context", {}).values()):
+            return Response({"error": "context values must be scalar for public keys"}, status=400)
+        return None

--- a/src/bitcaster/api/permissions.py
+++ b/src/bitcaster/api/permissions.py
@@ -9,6 +9,7 @@ from rest_framework.views import APIView
 from ..auth.constants import Grant
 from ..exceptions import InvalidGrantError
 from ..models import ApiKey, User
+from ..models.key import KeyKind
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +29,18 @@ class ApiKeyAuthentication(authentication.TokenAuthentication):
 
 
 class ApiBasePermission(permissions.BasePermission):
+    def _check_public_key(self, request: "Request", token: "ApiKey") -> bool:
+        if token.kind != KeyKind.PUBLIC:
+            return True
+        if token.grants != [Grant.EVENT_TRIGGER]:
+            raise InvalidGrantError(f"Public keys can only trigger events ({token})")
+        if not token.application_id:
+            raise InvalidGrantError(f"Public key not enabled for application scope ({token})")
+        origin = request.headers.get("Origin", "")
+        if not origin or origin not in (token.origins or []):
+            raise InvalidGrantError(f"Origin not allowed for {token}")
+        return True
+
     def _check_valid_scope(self, token: "ApiKey", view: "APIView") -> bool:
         if "org" in view.kwargs and view.kwargs["org"] != token.organization.slug:
             raise InvalidGrantError(f"Invalid organization for {token}")
@@ -60,7 +73,11 @@ class ApiApplicationPermission(ApiBasePermission):
                 and request.user.is_authenticated
                 and request.user.is_superuser
             )
-        return isinstance(request.auth, ApiKey) and self._check_valid_scope(request.auth, view)
+        return (
+            isinstance(request.auth, ApiKey)
+            and self._check_valid_scope(request.auth, view)
+            and self._check_public_key(request, request.auth)
+        )
 
     def has_object_permission(self, request: Request, view: "APIView", obj: "Model") -> bool:
         if getattr(request, "auth", None) is None:
@@ -69,4 +86,8 @@ class ApiApplicationPermission(ApiBasePermission):
                 and request.user.is_authenticated
                 and request.user.is_superuser
             )
-        return isinstance(request.auth, ApiKey) and self._check_valid_scope(request.auth, view)
+        return (
+            isinstance(request.auth, ApiKey)
+            and self._check_valid_scope(request.auth, view)
+            and self._check_public_key(request, request.auth)
+        )

--- a/src/bitcaster/api/throttling.py
+++ b/src/bitcaster/api/throttling.py
@@ -9,6 +9,8 @@ from rest_framework.views import APIView
 
 from django.core.cache import cache, caches
 
+from bitcaster.models.key import KeyKind
+
 # Rate limiting with Sliding Window using LUA for atomicity
 LUA_SLIDING_WINDOW = """
 local key = KEYS[1]
@@ -59,6 +61,7 @@ class SlidingWindowThrottle(BaseThrottle):
 
     rate: int = 30
     window: int = 60  # seconds
+    public_rate: int = 10  # stricter limit for PUBLIC keys
 
     def _get_attr(self, view: Any, attr_name: str, default: int) -> int:
         action_name: str | None = getattr(view, "action", None)
@@ -87,14 +90,20 @@ class SlidingWindowThrottle(BaseThrottle):
     def allow_request(self, request: Request, view: APIView) -> bool:
         if request.auth:
             key = f"throttle_{request.auth.id}"
+            rate = self.get_rate(view)
+            if getattr(request.auth, "kind", None) == KeyKind.PUBLIC:
+                rate = min(rate, self.public_rate)
+                origin = request.headers.get("Origin", "none")
+                key = f"{key}_{origin}"
         elif request.user.is_authenticated:
             key = f"throttle_{request.user.id}"
+            rate = self.get_rate(view)
         else:
             key = f"throttle_ip_{self.get_ident(request)}"
+            rate = self.get_rate(view)
 
         now: float = time.time()
         member_id: str = f"{now}_{uuid.uuid4()}"
-        rate: int = self.get_rate(view)
         window: int = self.get_window(view)
 
         try:

--- a/src/bitcaster/config/settings.py
+++ b/src/bitcaster/config/settings.py
@@ -96,6 +96,7 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.locale.LocaleMiddleware",
+    "bitcaster.middleware.cors.BrowserCorsMiddleware",
     "bitcaster.middleware.errors.ExceptionHandlingMiddleware",
     "csp.middleware.CSPMiddleware",
     "bitcaster.middleware.user_agent.UserAgentMiddleware",

--- a/src/bitcaster/middleware/cors.py
+++ b/src/bitcaster/middleware/cors.py
@@ -1,0 +1,54 @@
+from typing import TYPE_CHECKING
+
+from django.http import HttpResponse, JsonResponse
+
+from bitcaster.models import ApiKey
+from bitcaster.models.key import KeyKind
+
+if TYPE_CHECKING:
+    from typing import Callable
+
+    from django.http import HttpRequest, HttpResponseBase
+
+ALLOWED_METHODS = ("POST", "OPTIONS")
+ALLOWED_HEADERS = ("authorization", "content-type")
+
+
+class BrowserCorsMiddleware:
+    """CORS handling for PUBLIC API keys.
+
+    Public keys are bound to an allowlist of origins and are meant to be used
+    from browser clients. This middleware:
+
+    - answers ``OPTIONS`` preflight requests for ``/api/`` paths carrying a
+      valid PUBLIC key whose ``Origin`` is allowed
+    - rejects actual cross-origin ``/api/`` requests whose ``Origin`` is not
+      declared on the key
+    - attaches the ``Access-Control-Allow-Origin`` header to allowed responses
+    """
+
+    def __init__(self, get_response: "Callable[[HttpRequest], HttpResponseBase]") -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: "HttpRequest") -> "HttpResponseBase":
+        if not request.path.startswith("/api/") or not request.META.get("HTTP_AUTHORIZATION"):
+            return self.get_response(request)
+
+        token = request.META["HTTP_AUTHORIZATION"].removeprefix("Key ").strip()
+        key = ApiKey.objects.filter(kind=KeyKind.PUBLIC, key=token).first()
+        if key is None:
+            return self.get_response(request)
+
+        origin = request.headers.get("Origin", "")
+        if not origin or origin not in (key.origins or []):
+            return JsonResponse({"detail": "Origin not allowed for this key"}, status=403)
+
+        if request.method == "OPTIONS":
+            response: "HttpResponseBase" = HttpResponse(status=200)
+        else:
+            response = self.get_response(request)
+        response["Access-Control-Allow-Origin"] = origin
+        response["Access-Control-Allow-Methods"] = ", ".join(ALLOWED_METHODS)
+        response["Access-Control-Allow-Headers"] = ", ".join(ALLOWED_HEADERS)
+        response["Vary"] = "Origin"
+        return response

--- a/src/bitcaster/migrations/0036_apikey_kind_origins_allowed_events.py
+++ b/src/bitcaster/migrations/0036_apikey_kind_origins_allowed_events.py
@@ -1,0 +1,50 @@
+# Generated manually
+
+from django.contrib.postgres.fields import ArrayField
+from django.db import migrations, models
+
+import bitcaster.models.key
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("bitcaster", "0035_applicationmembership_active_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="apikey",
+            name="kind",
+            field=models.CharField(
+                choices=[("SERVER", "Server"), ("PUBLIC", "Public")],
+                default=bitcaster.models.key.KeyKind["SERVER"],
+                help_text="PUBLIC keys are bound to declared origins and restricted to event triggering.",
+                max_length=16,
+                verbose_name="Kind",
+            ),
+        ),
+        migrations.AddField(
+            model_name="apikey",
+            name="origins",
+            field=ArrayField(
+                base_field=models.CharField(blank=True, max_length=255, null=True),
+                blank=True,
+                help_text="Allowed origins for PUBLIC keys. Requests with other origins are rejected.",
+                null=True,
+                size=None,
+                verbose_name="Origins",
+            ),
+        ),
+        migrations.AddField(
+            model_name="apikey",
+            name="allowed_events",
+            field=ArrayField(
+                base_field=models.CharField(blank=True, max_length=64, null=True),
+                blank=True,
+                help_text="Optional event slug allowlist for PUBLIC keys. Empty means any event of the application.",
+                null=True,
+                size=None,
+                verbose_name="Allowed events",
+            ),
+        ),
+    ]

--- a/src/bitcaster/models/key.py
+++ b/src/bitcaster/models/key.py
@@ -5,6 +5,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 from django import forms
 from django.contrib.postgres.fields import ArrayField
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.forms.widgets import CheckboxSelectMultiple
 from django.utils.crypto import RANDOM_STRING_CHARS, get_random_string
@@ -19,6 +20,11 @@ from .user import User
 logger = logging.getLogger(__name__)
 
 TOKEN_CHARS = f"{RANDOM_STRING_CHARS}-_~."
+
+
+class KeyKind(models.TextChoices):
+    SERVER = "SERVER", _("Server")
+    PUBLIC = "PUBLIC", _("Public")
 
 
 def make_token() -> str:
@@ -80,6 +86,27 @@ class ApiKey(Scoped3Mixin, BitcasterBaseModel):
         null=True,
         help_text=_("grants for this key"),
     )
+    kind = models.CharField(
+        verbose_name=_("Kind"),
+        max_length=16,
+        choices=KeyKind.choices,
+        default=KeyKind.SERVER,
+        help_text=_("PUBLIC keys are bound to declared origins and restricted to event triggering."),
+    )
+    origins = ArrayField(
+        models.CharField(max_length=255, blank=True, null=True),
+        verbose_name=_("Origins"),
+        blank=True,
+        null=True,
+        help_text=_("Allowed origins for PUBLIC keys. Requests with other origins are rejected."),
+    )
+    allowed_events = ArrayField(
+        models.CharField(max_length=64, blank=True, null=True),
+        verbose_name=_("Allowed events"),
+        blank=True,
+        null=True,
+        help_text=_("Optional event slug allowlist for PUBLIC keys. Empty means any event of the application."),
+    )
     environments = ArrayField(
         models.CharField(max_length=20, blank=True, null=True),
         verbose_name=_("Environments"),
@@ -94,6 +121,28 @@ class ApiKey(Scoped3Mixin, BitcasterBaseModel):
         unique_together = (("name", "user"),)
         verbose_name = _("Api Key")
         verbose_name_plural = _("Api Keys")
+
+    def clean(self) -> None:
+        super().clean()
+        if self.kind == KeyKind.PUBLIC:
+            if not self.application_id:
+                raise ValidationError(_("Public keys must be pinned to an application"))
+            if not self.grants:
+                self.grants = [Grant.EVENT_TRIGGER]
+            elif self.grants != [Grant.EVENT_TRIGGER]:
+                raise ValidationError(_("Public keys can only have the EVENT_TRIGGER grant"))
+            if not self.origins:
+                raise ValidationError(_("Public keys must declare at least one allowed origin"))
+            for origin in self.origins:
+                if urlsplit(origin).scheme not in ("http", "https"):
+                    raise ValidationError(_("Invalid origin: %(origin)s") % {"origin": origin})
+        if self.allowed_events:
+            if not self.application_id:
+                raise ValidationError(_("Allowed events require an application"))
+            available = set(self.application.events.values_list("slug", flat=True))
+            unknown = [slug for slug in self.allowed_events if slug is not None and slug not in available]
+            if unknown:
+                raise ValidationError(_("Unknown events for application: %(slugs)s") % {"slugs": ", ".join(unknown)})
 
     def get_bae(self) -> str:
         password = self.key

--- a/tests/admin/test_admin_apikey.py
+++ b/tests/admin/test_admin_apikey.py
@@ -14,11 +14,13 @@ from django_webtest import DjangoTestApp, DjangoWebtestResponse
 from django_webtest.pytest_plugin import MixinWithInstanceVariables
 
 from bitcaster.auth.constants import Grant
+from bitcaster.models import ApiKey
+from bitcaster.models.key import KeyKind
 
 if TYPE_CHECKING:
     from django.db.models.options import Options
 
-    from bitcaster.models import ApiKey, Application
+    from bitcaster.models import Application
 
 
 @pytest.fixture
@@ -115,6 +117,48 @@ def test_add_check_environments(app: "DjangoTestApp", api_key: "ApiKey") -> None
     assert res.status_code == 302, res.context["adminform"].form.errors
 
 
+def test_add_public_key(app: DjangoTestApp, api_key: "ApiKey") -> None:
+    url = reverse("admin:bitcaster_apikey_add")
+    res = app.get(url)
+    frm = res.forms["apikey_form"]
+    frm["application"].force_value(api_key.application.pk)
+    frm["organization"].force_value(api_key.organization.pk)
+    frm["name"] = "Public-1"
+    frm["kind"] = KeyKind.PUBLIC
+    frm.fields["origins"][0].value = "https://example.com"
+    res = frm.submit()
+    assert res.status_code == 302, res.context["adminform"].form.errors
+
+    key = ApiKey.objects.get(name="Public-1")
+    assert key.kind == KeyKind.PUBLIC
+    assert key.grants == [Grant.EVENT_TRIGGER]
+    assert key.origins == ["https://example.com"]
+
+
+def test_add_public_key_requires_origin(app: DjangoTestApp, api_key: "ApiKey") -> None:
+    url = reverse("admin:bitcaster_apikey_add")
+    res = app.get(url)
+    frm = res.forms["apikey_form"]
+    frm["application"].force_value(api_key.application.pk)
+    frm["name"] = "Public-2"
+    frm["kind"] = KeyKind.PUBLIC
+    res = frm.submit(expect_errors=True)
+    assert res.status_code == 200
+    assert "origins" in res.context["adminform"].form.errors
+
+
+def test_add_public_key_requires_application(app: DjangoTestApp, api_key: "ApiKey") -> None:
+    url = reverse("admin:bitcaster_apikey_add")
+    res = app.get(url)
+    frm = res.forms["apikey_form"]
+    frm["name"] = "Public-3"
+    frm["kind"] = KeyKind.PUBLIC
+    frm.fields["origins"][0].value = "https://example.com"
+    res = frm.submit(expect_errors=True)
+    assert res.status_code == 200
+    assert "application" in res.context["adminform"].form.errors
+
+
 def test_edit_apikey_without_project(app: DjangoTestApp, db: Any) -> None:
     from testutils.factories import ApiKeyFactory
 
@@ -152,3 +196,44 @@ def test_show_key(app: DjangoTestApp, root: bool) -> None:
     with mock.patch("bitcaster.admin.api_key.is_root", return_value=root):
         res: DjangoWebtestResponse = app.get(url)
         assert (api_key.key in res.text) is root
+
+
+def test_add_form_hides_allowed_events(app: DjangoTestApp) -> None:
+    url = reverse("admin:bitcaster_apikey_add")
+    res = app.get(url)
+    assert "allowed_events" not in res.forms["apikey_form"].fields
+
+
+def test_change_form_hides_allowed_events_without_application(app: DjangoTestApp, db: Any) -> None:
+    from testutils.factories import ApiKeyFactory
+
+    key = ApiKeyFactory(application=None)
+    url = reverse("admin:bitcaster_apikey_change", args=[key.pk])
+    res = app.get(url)
+    assert res.status_code == 200
+    assert "allowed_events" not in res.forms["apikey_form"].fields
+
+
+def test_change_form_shows_allowed_events(app: DjangoTestApp, api_key: "ApiKey") -> None:
+    from testutils.factories import EventFactory
+
+    event = EventFactory(application=api_key.application)
+    url = reverse("admin:bitcaster_apikey_change", args=[api_key.pk])
+    res = app.get(url)
+    frm = res.forms["apikey_form"]
+    assert "allowed_events" in frm.fields
+    assert f'value="{event.slug}"' in res.text
+
+
+def test_change_form_save_allowed_events(app: DjangoTestApp, api_key: "ApiKey") -> None:
+    from testutils.factories import EventFactory
+
+    event = EventFactory(application=api_key.application)
+    url = reverse("admin:bitcaster_apikey_change", args=[api_key.pk])
+    res = app.get(url)
+    frm = res.forms["apikey_form"]
+    frm["allowed_events"] = [event.slug]
+    res = frm.submit()
+    assert res.status_code == 302, res.context["adminform"].form.errors
+    api_key.refresh_from_db()
+    assert api_key.allowed_events == [event.slug]

--- a/tests/api/test_api_authentication.py
+++ b/tests/api/test_api_authentication.py
@@ -126,7 +126,7 @@ def test_public_key_wrong_grants(rf: "RequestFactory", public_key: "ApiKey") -> 
     public_key.save()
     perm = ApiApplicationPermission()
     view = MagicMock(spec=EventTrigger)
-    view.grants = [Grant.EVENT_TRIGGER]
+    view.grants = [Grant.EVENT_LIST]
     view.kwargs = {
         "org": public_key.organization.slug,
         "prj": public_key.project.slug,
@@ -140,7 +140,7 @@ def test_public_key_wrong_grants(rf: "RequestFactory", public_key: "ApiKey") -> 
     request.auth = public_key
     request.user = public_key.user
 
-    with pytest.raises(InvalidGrantError):
+    with pytest.raises(InvalidGrantError, match="Public keys can only trigger events"):
         perm.has_permission(request, view)
 
 

--- a/tests/api/test_api_authentication.py
+++ b/tests/api/test_api_authentication.py
@@ -6,9 +6,11 @@ from rest_framework.test import APIClient
 import pytest
 from unittest.mock import MagicMock
 
-from bitcaster.api.event import EventList
-from bitcaster.api.permissions import ApiKeyAuthentication
+from bitcaster.api.event import EventList, EventTrigger
+from bitcaster.api.permissions import ApiApplicationPermission, ApiKeyAuthentication
 from bitcaster.auth.constants import Grant
+from bitcaster.exceptions import InvalidGrantError
+from bitcaster.models.key import KeyKind
 
 if TYPE_CHECKING:
     from django.test.client import RequestFactory
@@ -62,3 +64,122 @@ def test_handle_permission_error(client: APIClient, key: "ApiKey") -> None:
 
     res = client.get(url, data={})
     assert res.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.fixture
+def public_key(admin_user: "User") -> "ApiKey":
+    from testutils.factories import ApiKeyFactory, EventFactory
+
+    event = EventFactory()
+    return ApiKeyFactory(
+        user=admin_user,
+        grants=[Grant.EVENT_TRIGGER],
+        application=event.application,
+        kind=KeyKind.PUBLIC,
+        origins=["https://example.com"],
+    )
+
+
+def test_public_key_origin_mismatch(rf: "RequestFactory", public_key: "ApiKey") -> None:
+    perm = ApiApplicationPermission()
+    view = MagicMock(spec=EventTrigger)
+    view.grants = [Grant.EVENT_TRIGGER]
+    view.kwargs = {
+        "org": public_key.organization.slug,
+        "prj": public_key.project.slug,
+        "app": public_key.application.slug,
+    }
+    request = rf.post(
+        "/api/o/o/p/p/a/a/e/evt/trigger/",
+        HTTP_AUTHORIZATION=f"Key {public_key.key}",
+        HTTP_ORIGIN="https://evil.example",
+    )
+    request.auth = public_key
+    request.user = public_key.user
+
+    with pytest.raises(InvalidGrantError):
+        perm.has_permission(request, view)
+
+
+def test_public_key_origin_match(rf: "RequestFactory", public_key: "ApiKey") -> None:
+    perm = ApiApplicationPermission()
+    view = MagicMock(spec=EventTrigger)
+    view.grants = [Grant.EVENT_TRIGGER]
+    view.kwargs = {
+        "org": public_key.organization.slug,
+        "prj": public_key.project.slug,
+        "app": public_key.application.slug,
+    }
+    request = rf.post(
+        "/api/o/o/p/p/a/a/e/evt/trigger/",
+        HTTP_AUTHORIZATION=f"Key {public_key.key}",
+        HTTP_ORIGIN="https://example.com",
+    )
+    request.auth = public_key
+    request.user = public_key.user
+
+    assert perm.has_permission(request, view) is True
+
+
+def test_public_key_wrong_grants(rf: "RequestFactory", public_key: "ApiKey") -> None:
+    public_key.grants = [Grant.EVENT_LIST]
+    public_key.save()
+    perm = ApiApplicationPermission()
+    view = MagicMock(spec=EventTrigger)
+    view.grants = [Grant.EVENT_TRIGGER]
+    view.kwargs = {
+        "org": public_key.organization.slug,
+        "prj": public_key.project.slug,
+        "app": public_key.application.slug,
+    }
+    request = rf.post(
+        "/api/o/o/p/p/a/a/e/evt/trigger/",
+        HTTP_AUTHORIZATION=f"Key {public_key.key}",
+        HTTP_ORIGIN="https://example.com",
+    )
+    request.auth = public_key
+    request.user = public_key.user
+
+    with pytest.raises(InvalidGrantError):
+        perm.has_permission(request, view)
+
+
+def test_public_key_requires_application_scope(rf: "RequestFactory", public_key: "ApiKey") -> None:
+    public_key.application = None
+    public_key.project = None
+    public_key.save()
+    perm = ApiApplicationPermission()
+    view = MagicMock(spec=EventTrigger)
+    view.grants = [Grant.EVENT_TRIGGER]
+    view.kwargs = {"org": public_key.organization.slug}
+    request = rf.post(
+        "/api/o/o/p/p/a/a/e/evt/trigger/",
+        HTTP_AUTHORIZATION=f"Key {public_key.key}",
+        HTTP_ORIGIN="https://example.com",
+    )
+    request.auth = public_key
+    request.user = public_key.user
+
+    with pytest.raises(InvalidGrantError):
+        perm.has_permission(request, view)
+
+
+def test_public_key_rejected_on_list_events(rf: "RequestFactory", public_key: "ApiKey") -> None:
+    perm = ApiApplicationPermission()
+    view = MagicMock(spec=EventList)
+    view.grants = [Grant.EVENT_LIST]
+    view.kwargs = {
+        "org": public_key.organization.slug,
+        "prj": public_key.project.slug,
+        "app": public_key.application.slug,
+    }
+    request = rf.get(
+        "/api/o/o/p/p/a/a/e/",
+        HTTP_AUTHORIZATION=f"Key {public_key.key}",
+        HTTP_ORIGIN="https://example.com",
+    )
+    request.auth = public_key
+    request.user = public_key.user
+
+    with pytest.raises(InvalidGrantError):
+        perm.has_permission(request, view)

--- a/tests/api/test_api_throttling.py
+++ b/tests/api/test_api_throttling.py
@@ -116,3 +116,36 @@ def test_sliding_window_fallback_rejection(api_factory: APIRequestFactory, monke
     assert view(api_factory.get(url)).status_code == status.HTTP_200_OK
     # 3rd request should hit Line 111 (return False)
     assert view(api_factory.get(url)).status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+
+class MockPublicView(APIView):
+    throttle_classes = [SlidingWindowThrottle]
+    permission_classes = [AllowAny]
+    throttle_rate = 30
+
+
+@pytest.mark.django_db
+def test_sliding_window_public_key_rate(api_factory: APIRequestFactory) -> None:
+    """
+    PUBLIC keys are capped at the public_rate (10/min) regardless of the view rate
+    and the budget is scoped per origin.
+    """
+    from testutils.factories import ApiKeyFactory
+
+    from bitcaster.models.key import KeyKind
+
+    api_key = ApiKeyFactory(name=f"public-throttle-{uuid.uuid4()}", kind=KeyKind.PUBLIC, origins=["https://a.example"])
+    throttle = SlidingWindowThrottle()
+    view = MockPublicView()
+
+    for _ in range(10):
+        request = api_factory.get("/fake-endpoint/", HTTP_ORIGIN="https://a.example")
+        request.auth = api_key
+        assert throttle.allow_request(request, view) is True
+    request = api_factory.get("/fake-endpoint/", HTTP_ORIGIN="https://a.example")
+    request.auth = api_key
+    assert throttle.allow_request(request, view) is False
+
+    request = api_factory.get("/fake-endpoint/", HTTP_ORIGIN="https://b.example")
+    request.auth = api_key
+    assert throttle.allow_request(request, view) is True

--- a/tests/api/test_api_trigger.py
+++ b/tests/api/test_api_trigger.py
@@ -13,6 +13,7 @@ from bitcaster.auth.constants import Grant
 from bitcaster.constants import SystemEvent
 from bitcaster.models import Application
 from bitcaster.models.choices import FILTERING_EXTERNAL
+from bitcaster.models.key import KeyKind
 from bitcaster.runner.tasks import process_occurrence
 
 if TYPE_CHECKING:
@@ -118,6 +119,49 @@ def data_dynamic(admin_user: "User", email_channel: "Channel") -> "Context":
         "assignments": assignments,
         "channel": email_channel,
         "notification": n,
+        "url": "/api/o/{}/p/{}/a/{}/e/{}/trigger/".format(
+            event.application.project.organization.slug,
+            event.application.project.slug,
+            event.application.slug,
+            event.slug,
+        ),
+    }
+
+
+@pytest.fixture
+def public_data(admin_user: "User", email_channel: "Channel") -> "Context":
+    from testutils.factories import (
+        ApiKeyFactory,
+        AssignmentFactory,
+        EventFactory,
+        MessageTemplateFactory,
+        NotificationFactory,
+    )
+
+    from bitcaster.constants import bitcaster
+
+    event: "Event" = EventFactory.create(
+        channels=[email_channel], messages=[MessageTemplateFactory(channel=email_channel)]
+    )
+    assignments = [AssignmentFactory.create(channel=email_channel) for __ in range(4)]
+
+    n = NotificationFactory.create(distribution__recipients=assignments, event=event)
+
+    key = ApiKeyFactory.create(
+        user=admin_user,
+        grants=[Grant.EVENT_TRIGGER],
+        application=event.application,
+        kind=KeyKind.PUBLIC,
+        origins=["https://example.com"],
+    )
+    return {
+        "event": event,
+        "key": key,
+        "user": admin_user,
+        "system_user": bitcaster.system_user,
+        "channel": email_channel,
+        "notification": n,
+        "assignments": assignments,
         "url": "/api/o/{}/p/{}/a/{}/e/{}/trigger/".format(
             event.application.project.organization.slug,
             event.application.project.slug,
@@ -604,3 +648,90 @@ def test_trigger_auto_create_options(client: APIClient, data: "Context", opt) ->
         with key_grants(api_key, [Grant.EVENT_TRIGGER, Grant.EVENT_AUTO_CREATE]):
             res = client.post(url, data={}, format="json")
     assert res.status_code in [status.HTTP_201_CREATED, status.HTTP_400_BAD_REQUEST]
+
+
+def test_trigger_public_key(client: APIClient, public_data: "Context") -> None:
+    api_key = public_data["key"]
+    url: str = public_data["url"]
+    client.credentials(HTTP_AUTHORIZATION=f"Key {api_key.key}", HTTP_ORIGIN="https://example.com")
+
+    res = client.post(url, data={"context": {"key": "value"}}, format="json")
+    assert res.status_code == status.HTTP_201_CREATED, res.json()
+
+
+def test_trigger_public_key_wrong_origin(client: APIClient, public_data: "Context") -> None:
+    api_key = public_data["key"]
+    url: str = public_data["url"]
+    client.credentials(HTTP_AUTHORIZATION=f"Key {api_key.key}", HTTP_ORIGIN="https://evil.example")
+
+    res = client.post(url, data={"context": {}}, format="json")
+    assert res.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_trigger_public_key_no_origin(client: APIClient, public_data: "Context") -> None:
+    api_key = public_data["key"]
+    url: str = public_data["url"]
+    client.credentials(HTTP_AUTHORIZATION=f"Key {api_key.key}")
+
+    res = client.post(url, data={"context": {}}, format="json")
+    assert res.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_trigger_public_key_limit_to(client: APIClient, public_data: "Context") -> None:
+    api_key = public_data["key"]
+    url: str = public_data["url"]
+    client.credentials(HTTP_AUTHORIZATION=f"Key {api_key.key}", HTTP_ORIGIN="https://example.com")
+
+    res = client.post(url, data={"options": {"limit_to": ["user@example.com"]}}, format="json")
+    assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_trigger_public_key_filters(client: APIClient, public_data: "Context") -> None:
+    api_key = public_data["key"]
+    url: str = public_data["url"]
+    client.credentials(HTTP_AUTHORIZATION=f"Key {api_key.key}", HTTP_ORIGIN="https://example.com")
+
+    res = client.post(url, data={"options": {"filters": {"include": []}}}, format="json")
+    assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_trigger_public_key_non_scalar_context(client: APIClient, public_data: "Context") -> None:
+    api_key = public_data["key"]
+    url: str = public_data["url"]
+    client.credentials(HTTP_AUTHORIZATION=f"Key {api_key.key}", HTTP_ORIGIN="https://example.com")
+
+    res = client.post(url, data={"context": {"nested": {"a": 1}}}, format="json")
+    assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_trigger_public_key_allowed_events(client: APIClient, public_data: "Context") -> None:
+    api_key = public_data["key"]
+    event: Event = public_data["event"]
+    api_key.allowed_events = ["other-event"]
+    api_key.save()
+    client.credentials(HTTP_AUTHORIZATION=f"Key {api_key.key}", HTTP_ORIGIN="https://example.com")
+
+    url = "/api/o/{}/p/{}/a/{}/e/{}/trigger/".format(
+        event.application.project.organization.slug,
+        event.application.project.slug,
+        event.application.slug,
+        event.slug,
+    )
+    res = client.post(url, data={"context": {}}, format="json")
+    assert res.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_trigger_public_key_auto_create_denied(client: APIClient, public_data: "Context") -> None:
+    api_key = public_data["key"]
+    event: Event = public_data["event"]
+    client.credentials(HTTP_AUTHORIZATION=f"Key {api_key.key}", HTTP_ORIGIN="https://example.com")
+
+    url = "/api/o/{}/p/{}/a/{}/e/{}/trigger/".format(
+        event.application.project.organization.slug,
+        event.application.project.slug,
+        event.application.slug,
+        uuid.uuid4().hex,
+    )
+    with configure_model(event.application, auto_create_event=True):
+        res = client.post(url, data={"context": {}}, format="json")
+    assert res.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/middleware/test_middleware_cors.py
+++ b/tests/middleware/test_middleware_cors.py
@@ -1,0 +1,109 @@
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from unittest.mock import Mock
+
+from django.http import HttpResponse
+
+from bitcaster.middleware.cors import BrowserCorsMiddleware
+from bitcaster.models.key import KeyKind
+
+if TYPE_CHECKING:
+    from bitcaster.models import ApiKey
+
+pytestmark = [pytest.mark.api, pytest.mark.django_db]
+
+
+@pytest.fixture
+def public_key(admin_user: "ApiKey") -> "ApiKey":
+    from testutils.factories import ApiKeyFactory
+
+    return ApiKeyFactory(
+        user=admin_user,
+        application=None,
+        project=None,
+        kind=KeyKind.PUBLIC,
+        grants=["EVENT_TRIGGER"],
+        origins=["https://example.com"],
+    )
+
+
+def _call(request: Any, get_response: Any = None) -> Any:
+    middleware = BrowserCorsMiddleware(get_response or Mock(return_value=Mock(status_code=200)))
+    return middleware(request)
+
+
+def test_preflight_allowed(public_key: "ApiKey", rf: Any) -> None:
+    request = rf.options(
+        "/api/o/o/p/p/a/a/e/evt/trigger/",
+        HTTP_AUTHORIZATION=f"Key {public_key.key}",
+        HTTP_ORIGIN="https://example.com",
+        HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
+    )
+    response = _call(request)
+    assert response.status_code == 200
+    assert response["Access-Control-Allow-Origin"] == "https://example.com"
+    assert "POST" in response["Access-Control-Allow-Methods"]
+    assert "authorization" in response["Access-Control-Allow-Headers"]
+
+
+def test_preflight_denied(public_key: "ApiKey", rf: Any) -> None:
+    request = rf.options(
+        "/api/o/o/p/p/a/a/e/evt/trigger/",
+        HTTP_AUTHORIZATION=f"Key {public_key.key}",
+        HTTP_ORIGIN="https://evil.example",
+    )
+    response = _call(request)
+    assert response.status_code == 403
+
+
+def test_actual_request_allowed(public_key: "ApiKey", rf: Any) -> None:
+    get_response = Mock(return_value=HttpResponse(status=201))
+    request = rf.post(
+        "/api/o/o/p/p/a/a/e/evt/trigger/",
+        HTTP_AUTHORIZATION=f"Key {public_key.key}",
+        HTTP_ORIGIN="https://example.com",
+    )
+    response = _call(request, get_response)
+    assert response.status_code == 201
+    assert response["Access-Control-Allow-Origin"] == "https://example.com"
+    get_response.assert_called_once()
+
+
+def test_actual_request_denied(public_key: "ApiKey", rf: Any) -> None:
+    get_response = Mock(return_value=HttpResponse(status=201))
+    request = rf.post(
+        "/api/o/o/p/p/a/a/e/evt/trigger/",
+        HTTP_AUTHORIZATION=f"Key {public_key.key}",
+        HTTP_ORIGIN="https://evil.example",
+    )
+    response = _call(request, get_response)
+    assert response.status_code == 403
+    get_response.assert_not_called()
+
+
+def test_missing_origin_denied(public_key: "ApiKey", rf: Any) -> None:
+    request = rf.post("/api/o/o/p/p/a/a/e/evt/trigger/", HTTP_AUTHORIZATION=f"Key {public_key.key}")
+    response = _call(request)
+    assert response.status_code == 403
+
+
+def test_server_key_passthrough(api_key: "ApiKey", rf: Any) -> None:
+    get_response = Mock(return_value=HttpResponse(status=200))
+    request = rf.post(
+        "/api/o/o/p/p/a/a/e/evt/trigger/",
+        HTTP_AUTHORIZATION=f"Key {api_key.key}",
+        HTTP_ORIGIN="https://evil.example",
+    )
+    response = _call(request, get_response)
+    assert response.status_code == 200
+    assert "Access-Control-Allow-Origin" not in response
+    get_response.assert_called_once()
+
+
+def test_no_auth_passthrough(rf: Any) -> None:
+    get_response = Mock(return_value=HttpResponse(status=200))
+    request = rf.post("/api/o/o/p/p/a/a/e/evt/trigger/", HTTP_ORIGIN="https://example.com")
+    response = _call(request, get_response)
+    assert response.status_code == 200
+    get_response.assert_called_once()

--- a/tests/models/test_model_apikey.py
+++ b/tests/models/test_model_apikey.py
@@ -1,4 +1,10 @@
+import pytest
+
+from django.core.exceptions import ValidationError
+
+from bitcaster.auth.constants import Grant
 from bitcaster.models import ApiKey, Application, User
+from bitcaster.models.key import KeyKind
 
 
 def test_manager_get_or_create(application: "Application", user: "User") -> None:
@@ -19,3 +25,78 @@ def test_manager_update_or_create(application: "Application", user: "User") -> N
     assert ApiKey.objects.update_or_create(user=user, defaults={"application": application})
     assert ApiKey.objects.update_or_create(user=user, defaults={"project": application.project})
     assert ApiKey.objects.update_or_create(user=user, defaults={"organization": application.project.organization})
+
+
+def test_public_key_valid(application: "Application", user: "User") -> None:
+    key = ApiKey(name="k", user=user, application=application, kind=KeyKind.PUBLIC, origins=["https://example.com"])
+    key.full_clean()
+
+
+def test_public_key_requires_application(application: "Application", user: "User") -> None:
+    key = ApiKey(name="k", user=user, kind=KeyKind.PUBLIC, origins=["https://example.com"])
+    with pytest.raises(ValidationError):
+        key.full_clean()
+
+
+def test_public_key_requires_trigger_grant(application: "Application", user: "User") -> None:
+    key = ApiKey(
+        name="k",
+        user=user,
+        application=application,
+        kind=KeyKind.PUBLIC,
+        origins=["https://example.com"],
+        grants=[Grant.EVENT_TRIGGER, Grant.EVENT_LIST],
+    )
+    with pytest.raises(ValidationError):
+        key.full_clean()
+
+
+def test_public_key_requires_origin(application: "Application", user: "User") -> None:
+    key = ApiKey(name="k", user=user, application=application, kind=KeyKind.PUBLIC)
+    with pytest.raises(ValidationError):
+        key.full_clean()
+
+
+def test_public_key_invalid_origin(application: "Application", user: "User") -> None:
+    key = ApiKey(name="k", user=user, application=application, kind=KeyKind.PUBLIC, origins=["not-an-origin"])
+    with pytest.raises(ValidationError):
+        key.full_clean()
+
+
+def test_server_key_origin_not_required(application: "Application", user: "User") -> None:
+    key = ApiKey(name="k", user=user, application=application, kind=KeyKind.SERVER, grants=[Grant.EVENT_TRIGGER])
+    key.full_clean()
+
+
+def test_public_key_allowed_events_valid(application: "Application", user: "User") -> None:
+    from testutils.factories import EventFactory
+
+    event = EventFactory(application=application)
+    key = ApiKey(
+        name="k",
+        user=user,
+        application=application,
+        kind=KeyKind.PUBLIC,
+        origins=["https://example.com"],
+        allowed_events=[event.slug],
+    )
+    key.full_clean()
+
+
+def test_public_key_allowed_events_unknown(application: "Application", user: "User") -> None:
+    key = ApiKey(
+        name="k",
+        user=user,
+        application=application,
+        kind=KeyKind.PUBLIC,
+        origins=["https://example.com"],
+        allowed_events=["unknown-event"],
+    )
+    with pytest.raises(ValidationError):
+        key.full_clean()
+
+
+def test_allowed_events_requires_application(user: "User") -> None:
+    key = ApiKey(name="k", user=user, allowed_events=["some-event"])
+    with pytest.raises(ValidationError):
+        key.full_clean()


### PR DESCRIPTION
### Summary

- Introduce a PUBLIC key kind with an origins whitelist for browser-based API access
- Add CORS middleware (`BrowserCorsMiddleware`) that validates origins for public keys
- Add permission checks rejecting public keys without an application scope or sufficient grants
- Update the admin form to require origins for public keys and infer the application from URL scope
- Add migration (`0036`) adding `kind`, `origins`, and `allowed_events` fields to ApiKey
- Add comprehensive tests covering the model, admin, permissions, throttling, CORS middleware, and event trigger

### Motivation

Support publishable API keys that can be used from browser clients with origin-based security, while preventing misuse by requiring application scoping and proper grants.

### Breaking Changes

- ApiKey model gains new required fields (`kind`, `origins`, `allowed_events`)
- Public keys without an application scope are now rejected

### Testing

- `tests/models/test_model_apikey.py` — model field validation and defaults
- `tests/admin/test_admin_apikey.py` — admin form validation for origins and application
- `tests/api/test_api_authentication.py` — permission checks for grants and scope
- `tests/api/test_api_throttling.py` — throttling behaviour
- `tests/api/test_api_trigger.py` — event trigger flow
- `tests/middleware/test_middleware_cors.py` — CORS middleware behaviour