### PR TITLE
chore(deps): bump boto3-stubs minimum version to 1.43

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ docs = [
   "pymdown-extensions>=11.0.1",
 ]
 mypy = [
-  "boto3-stubs>=1.34.105",
+  "boto3-stubs>=1.43",
   "djangorestframework-stubs",
   "mypy>=1.9",
   "mypy-boto3>=1.34.105",

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ docs = [
     { name = "pymdown-extensions", specifier = ">=11.0.1" },
 ]
 mypy = [
-    { name = "boto3-stubs", specifier = ">=1.34.105" },
+    { name = "boto3-stubs", specifier = ">=1.43" },
     { name = "djangorestframework-stubs" },
     { name = "mypy", specifier = ">=1.9" },
     { name = "mypy-boto3", specifier = ">=1.34.105" },


### PR DESCRIPTION
## Summary
- Raise the minimum required version of `boto3-stubs` (AWS SDK type stubs) from `>=1.34.105` to `>=1.43` in the `mypy` extra.
- Sync the matching specifier in `uv.lock`; no re-resolution needed as the lockfile already resolves `boto3-stubs` to 1.43.58.

## Motivation
Ensure the mypy type-checking environment always uses a recent-enough set of AWS type stubs, guaranteeing the latest stub coverage and mypy-plugin compatibility.

## Breaking Changes
None. The resolved dependency version is unchanged (1.43.58); only the declared minimum is raised.

## Testing Checklist
- [x] `tox -e lint` — PASS (pre-commit: ruff, djLint, migrations, semgrep)
- [x] `tox -e semgrep` — PASS (22 rules, 0 findings)
- [x] `tox -e mypy` — PASS (280 source files, no issues)
- [x] `tox -e tests` — PASS (1926 passed, 26 skipped, coverage 98.39%, diff-cover clean vs origin/develop)
