### PR TITLE
fix(admin): restore Save button on Event add page

### DIFF
--- a/src/bitcaster/admin/base.py
+++ b/src/bitcaster/admin/base.py
@@ -128,7 +128,7 @@ class BaseAdmin[T](
     ) -> HttpResponse:
         extra_context = extra_context or {}
 
-        extra_context["show_save_and_add_another"] = False
-        extra_context["show_save_and_continue"] = self.save_as_continue
+        extra_context.setdefault("show_save_and_add_another", False)
+        extra_context.setdefault("show_save_and_continue", self.save_as_continue)
 
         return super().changeform_view(request, object_id, form_url, extra_context)

--- a/tests/admin/test_admin_event.py
+++ b/tests/admin/test_admin_event.py
@@ -57,6 +57,23 @@ def test_add_event(app: "DjangoTestApp", application: "Application") -> None:
     assert res.status_code == 302
 
 
+def test_add_event_shows_save_and_continue(app: "DjangoTestApp", application: "Application") -> None:
+    url = reverse("admin:bitcaster_event_add")
+    res = app.get(url)
+    # two-step create: "Save and continue editing" is the only submit button on the add page
+    assert res.pyquery("#submit-row [name=_continue]")
+    assert not res.pyquery("#submit-row [name=_save]")
+    assert not res.pyquery("#submit-row [name=_addanother]")
+    assert not res.pyquery("#submit-row [name=_saveasnew]")
+
+
+def test_change_event_shows_save(app: "DjangoTestApp", event: "Event") -> None:
+    url = reverse("admin:bitcaster_event_change", args=[event.pk])
+    res = app.get(url)
+    assert res.pyquery("#submit-row [name=_save]")
+    assert res.pyquery("#submit-row [name=_continue]")
+
+
 def test_change_event(app: "DjangoTestApp", event: "Event") -> None:
     url = reverse("admin:bitcaster_event_change", args=[event.pk])
     res = app.get(url)

--- a/uv.lock
+++ b/uv.lock
@@ -1042,16 +1042,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.16"
+version = "5.2.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/26/889449d521ae508b26de715954faecd8bcf3f740affb81b2d146a83b42a5/django-5.2.16.tar.gz", hash = "sha256:59ea02020c3136fce14bef0bbece21a10a4febef5eed1c51c22ae468efa22200", size = 10890894, upload-time = "2026-07-07T13:52:17.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/d8/43e9d000519adceb189620b6869ff88031e046df91c2e9da72f8f6918399/django-5.2.17.tar.gz", hash = "sha256:9d4d93be539a18ab80d058eb515900e10951e04c537c5a6b394fc49528d3251f", size = 10889740, upload-time = "2026-08-04T15:04:03.173Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/13/1e5e3e4c15dcecb04281b3cb2a46a4670e1cef131068e202f6040df19224/django-5.2.16-py3-none-any.whl", hash = "sha256:04f354bf9d807a86ad1a8392fe3808d362358a8eafc322848e0e43e59b24371d", size = 8311943, upload-time = "2026-07-07T13:52:11.223Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f8/ce120525ca78f12b07daf65786679c5d0b54a75285a8958d3ae55e39da35/django-5.2.17-py3-none-any.whl", hash = "sha256:f04fb3b36ee119e1af4fa1d397d5fd6cf12700f49321e84d4f4c642c5b1973db", size = 8315563, upload-time = "2026-08-04T15:03:59.1Z" },
 ]
 
 [[package]]
@@ -1538,14 +1538,14 @@ wheels = [
 
 [[package]]
 name = "djangorestframework"
-version = "3.17.1"
+version = "3.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/d7/c016e69fac19ff8afdc89db9d31d9ae43ae031e4d1993b20aca179b8301a/djangorestframework-3.17.1.tar.gz", hash = "sha256:a6def5f447fe78ff853bff1d47a3c59bf38f5434b031780b351b0c73a62db1a5", size = 905742, upload-time = "2026-03-24T16:58:33.705Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/bc/de04e3d4dc65e8b926700956ee70d4f084f2005603d21122d4d0683006fd/djangorestframework-3.18.0.tar.gz", hash = "sha256:2323a5111837e0b784dcb8323abc78ecc54fa2a5af7aff2677cf50cdd849477f", size = 913667, upload-time = "2026-08-07T14:53:33.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/e1/2c516bdc83652b1a60c6119366ac2c0607b479ed05cd6093f916ca8928f8/djangorestframework-3.17.1-py3-none-any.whl", hash = "sha256:c3c74dd3e83a5a3efc37b3c18d92bd6f86a6791c7b7d4dff62bb068500e76457", size = 898844, upload-time = "2026-03-24T16:58:31.845Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d7/7461738e819b853275b35fd35712a85806c09a327e1fd5f8ff766bdd317e/djangorestframework-3.18.0-py3-none-any.whl", hash = "sha256:381fc44d3249c9565c5f723850855b734e99030eb30957a49f506d3fe11d7dcb", size = 900032, upload-time = "2026-08-07T14:53:31.881Z" },
 ]
 
 [[package]]
@@ -2954,11 +2954,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]
@@ -4840,14 +4840,14 @@ wheels = [
 
 [[package]]
 name = "webob"
-version = "1.8.10"
+version = "1.8.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "legacy-cgi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/f9/974eafebfd0bd442b8848899fe7d30675c93f750c313e1a6fe61acbde1e3/webob-1.8.10.tar.gz", hash = "sha256:1c963a11f307bc3f624fbab9dde737701eae255f32981b7a5486a88db1767c2b", size = 280796, upload-time = "2026-06-02T19:56:47.268Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/92/9329872e36be90e25ba616ac6e9ee8c1be4326a1ea3fdffcdabd0eb48efb/webob-1.8.11.tar.gz", hash = "sha256:aa8c27231070b135c025e567a9cd7eda03f4df71352ffaac740cb6a75f0f81a5", size = 286047, upload-time = "2026-08-02T06:26:26.063Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/21/fce134877fb6fc6ad3c464e4a07ede0ee9219f705d26a981ae58ea36ca13/webob-1.8.10-py2.py3-none-any.whl", hash = "sha256:e68ad87fda378191081965ab02a185391c26e4e926adec855c3b0286a8369d49", size = 115825, upload-time = "2026-06-02T19:56:44.765Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/71/370a65bc7726a1cbf478445c898c7affe907aa42e2e9e5bb38319db74115/webob-1.8.11-py2.py3-none-any.whl", hash = "sha256:4addd1d38d6a7fbe0eda22d45f25a40d74c8b290f3a99c0ac3d4023cf21f2da2", size = 118319, upload-time = "2026-08-02T06:26:24.765Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Problem                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                       
  Adding an Event from the admin (/admin/bitcaster/event/add/) rendered no submit button at all, making it impossible to create an Event from the UI.                                                                                                                  
                                                                                                                                                                                                                                                                       
  Cause                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                       
  Two changeform_view overrides collide in the MRO (EventAdmin → TwoStepCreateMixin → LockMixinAdmin → BaseAdmin):                                                                                                                                                     
                                                                                                                                                                                                                                                                       
  - TwoStepCreateMixin hides Save, Save as new, and Save and add another on the add page and sets show_save_and_continue = True, so "Save and continue editing" is the only submit button (two-step create).                                                           
  - BaseAdmin.changeform_view then unconditionally overwrote show_save_and_continue with self.save_as_continue, which EventAdmin sets to False — suppressing every submit button on the add page.                                                                      
                                                                                                                                                                                                                                                                       
  Fix                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                       
  BaseAdmin.changeform_view now uses setdefault, so values set by more specific mixins earlier in the MRO win; admins that don't set them keep the current behavior.                                                                                                   
                                                                                                                                                                                                                                                                       
  Tests                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                       
  - test_add_event_shows_save_and_continue — reproduces the bug (failed before the fix): the add page must render _continue and no other submit buttons.                                                                                                               
  - test_change_event_shows_save — guards the change page (both _save and _continue present).                                                                                                                                                                          
                                                                                                                                                                                                                                                                       
  The pre-existing test_add_event didn't catch this because webtest submits forms even without a submit button.

Also included                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                       
  chore(deps): bump django 5.2.17, djangorestframework 3.18.0, pip 26.2.1, webob 1.8.11 to clear pip-audit CVEs that were failing the tox security env (pre-existing, unrelated to this fix).                                                                          
                                                                                                                                                                                                                                                                       
  Full tox suite green: lint, semgrep, tests, mypy, docs, security, pkg_meta. 

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com># Legal Boilerplate

Look, I get it.
Contributing to Bitcaster, I retain all rights, title and interest in and to my contributions, and by keeping
this boilerplate intact I confirm that Bitcaster can use, modify, copy, and redistribute my contributions,
under Bitcaster's choice of terms.
